### PR TITLE
feat: Add reloadcog command and Utilities cog

### DIFF
--- a/byte_bot/byte_bot.py
+++ b/byte_bot/byte_bot.py
@@ -32,9 +32,16 @@ class ByteBot(commands.Bot):
     async def setup_hook(self) -> None:
         """Called when the bot is ready to load cogs and interact with the API."""
 
-        # TODO: Load cogs from the "cogs" directory. This allows us to modularize our commands and event listeners.
-        # for cog in SOME_LIST_OF_COGS:
-        #     await self.load_extension(cog)
+        # Load cogs from the cogs directory
+        cogs_to_load = [
+            "byte_bot.cogs.utilities",
+        ]
+        
+        for cog in cogs_to_load:
+            try:
+                await self.load_extension(cog)
+            except Exception as e:
+                log.error(f"Failed to load cog {cog}: {e}")
 
         synced = await self.tree.sync()  # Syncs the application commands (slash commands) with Discord.
         log.info(f"Added main cog commands... Synced {len(synced)} commands")

--- a/byte_bot/cogs/utilities.py
+++ b/byte_bot/cogs/utilities.py
@@ -1,0 +1,140 @@
+"""Utilities cog for byte-bot.
+
+This cog contains general utility commands for the bot, including the reloadcog command
+for hot-reloading cogs during development.
+"""
+
+import logging
+
+import discord
+from discord.ext import commands
+
+log = logging.getLogger(__name__)
+
+
+class Utilities(commands.Cog):
+    """General utility commands for the bot."""
+
+    def __init__(self, bot: commands.Bot):
+        """Initialize the Utilities cog.
+
+        Args:
+            bot: The bot instance.
+        """
+        self.bot = bot
+
+    @commands.hybrid_command(
+        name="reloadcog",
+        description="Reload one or more cogs without restarting the bot.",
+    )
+    @commands.is_owner()
+    async def reloadcog(
+        self, ctx: commands.Context, *, cog_names: str
+    ) -> None:
+        """Reload one or more cogs hot without restarting the bot.
+
+        This command is useful during development to test changes to cogs
+        without having to restart the entire bot and reconnect to Discord.
+
+        Args:
+            ctx: The command context.
+            cog_names: Space-separated list of cog names to reload.
+                      Cog names should be in the format 'cogs.cog_name'.
+
+        Examples:
+            +reloadcog cogs.utilities
+            +reloadcog cogs.utilities cogs.fun
+        """
+        # Split the input into individual cog names
+        cogs_to_reload = cog_names.split()
+
+        if not cogs_to_reload:
+            await ctx.send(
+                "❌ Please provide at least one cog name to reload.\n"
+                "Usage: `+reloadcog cogs.cog_name` or `+reloadcog cogs.cog1 cogs.cog2`"
+            )
+            return
+
+        results = []
+        success_count = 0
+        fail_count = 0
+
+        for cog_name in cogs_to_reload:
+            cog_name = cog_name.strip()
+
+            try:
+                # Attempt to reload the extension
+                await self.bot.reload_extension(cog_name)
+                results.append(f"✅ **{cog_name}**: Reloaded successfully")
+                success_count += 1
+                log.info(f"Reloaded cog: {cog_name}")
+
+            except commands.ExtensionNotFound:
+                results.append(
+                    f"❌ **{cog_name}**: Cog not found. "
+                    f"Make sure the cog exists in the cogs directory."
+                )
+                fail_count += 1
+                log.warning(f"Attempted to reload non-existent cog: {cog_name}")
+
+            except commands.ExtensionNotLoaded:
+                # Try to load it if it wasn't loaded
+                try:
+                    await self.bot.load_extension(cog_name)
+                    results.append(
+                        f"⚠️ **{cog_name}**: Was not loaded, now loaded successfully"
+                    )
+                    success_count += 1
+                    log.info(f"Loaded cog that was not previously loaded: {cog_name}")
+                except Exception as load_error:
+                    results.append(
+                        f"❌ **{cog_name}**: Failed to load - {str(load_error)}"
+                    )
+                    fail_count += 1
+                    log.error(f"Failed to load cog {cog_name}: {load_error}")
+
+            except commands.ExtensionFailed as e:
+                results.append(
+                    f"❌ **{cog_name}**: Failed to reload - {str(e.original)}"
+                )
+                fail_count += 1
+                log.error(f"Failed to reload cog {cog_name}: {e}")
+
+            except Exception as e:
+                results.append(f"❌ **{cog_name}**: Unexpected error - {str(e)}")
+                fail_count += 1
+                log.error(f"Unexpected error reloading cog {cog_name}: {e}")
+
+        # Create the embed response
+        embed = discord.Embed(
+            title="🔄 Cog Reload Results",
+            color=discord.Color.green() if fail_count == 0 else discord.Color.orange(),
+        )
+
+        # Add summary field
+        embed.add_field(
+            name="Summary",
+            value=f"✅ Success: {success_count} | ❌ Failed: {fail_count}",
+            inline=False,
+        )
+
+        # Add detailed results
+        embed.add_field(
+            name="Details",
+            value="\n".join(results) if results else "No cogs processed",
+            inline=False,
+        )
+
+        embed.set_footer(text=f"Requested by {ctx.author.display_name}")
+
+        await ctx.send(embed=embed)
+
+
+async def setup(bot: commands.Bot) -> None:
+    """Set up the Utilities cog.
+
+    Args:
+        bot: The bot instance.
+    """
+    await bot.add_cog(Utilities(bot))
+    log.info("Utilities cog loaded")


### PR DESCRIPTION
Implements #7

## Changes

- Add Utilities cog with `reloadcog` hybrid command
- Support reloading single or multiple cogs at once
- Handle invalid cog names and loading failures gracefully
- Load cogs automatically in `setup_hook`
- Add proper error handling and user feedback via Discord embeds

## Features

The `reloadcog` command:
- Accepts space-separated cog names (e.g., `+reloadcog cogs.utilities cogs.fun`)
- Handles various error cases:
  - `ExtensionNotFound`: Cog does not exist
  - `ExtensionNotLoaded`: Cog was not loaded (attempts to load it)
  - `ExtensionFailed`: Cog failed to load/reload
- Provides detailed results in a formatted Discord embed
- Restricted to bot owner only using `@commands.is_owner()`

## Testing

1. Load the bot with the new cog
2. Use `+reloadcog cogs.utilities` to reload the utilities cog
3. Try reloading multiple cogs: `+reloadcog cogs.utilities cogs.another`
4. Test error handling with invalid cog names

## Checklist

- [x] Implements `reloadcog` command as hybrid command
- [x] Accepts multiple cog names as parameters
- [x] Handles invalid cog names gracefully
- [x] Handles loading failures with proper error messages
- [x] Provides user feedback via embeds
- [x] Restricted to bot owner
- [x] Cogs are loaded automatically in `setup_hook`

Fixes #7