### PR TITLE
Add Utilities cog with reload command for dynamic cog management

### DIFF
--- a/byte_bot/cogs/Utilities.py
+++ b/byte_bot/cogs/Utilities.py
@@ -46,11 +46,26 @@ class Utilities(commands.Cog):
                 await self.bot.reload_extension(extension_name)
                 results.append(f"**{cog}** reloaded successfully.")
             except commands.ExtensionNotFound:
+                logger.exception(
+                    f"Failed to reload the {cog} cog - ExtensionNotFound"
+                )
                 results.append(f" **{cog}** not found.")
-            except commands.ExtensionFailed as e:
-                results.append(f" **{cog}** failed: {e}")
+            except commands.ExtensionFailed:
+                logger.exception(
+                    f"Failed to reload the {cog} cog due to ExtensionFailed"
+                )
+                results.append(f" **{cog}** failed")
             except commands.ExtensionNotLoaded:
+                logger.exception(
+                    f"Failed to reload the {cog} cog - ExtensionNotLoaded"
+                )
                 results.append(f"**{cog}** is not loaded yet.")
+            except Exception:
+                #if there is unexpected error so this will run 
+                logger.exception(
+                    f"Unexpected error while reloading the {cog} cog"
+                )
+                results.append(f"❌ **{cog}** unexpected error. Check logs.")
 
         # create an embed to display the results
         embed = discord.Embed(title="🔄 Cog Reload Report", color=discord.Color.blue())


### PR DESCRIPTION
I have implemented the `reloadcog` feature inside the Utilities Cog as requested.
- Added a `reloadcog` command using `commands.hybrid_command`
- Supports both prefix (`+reloadcog`) and slash (`/reloadcog`) usage
- Accepts multiple cogs using comma-separated input
- Uses `self.bot.reload_extension()` to reload specified cog(s)
- Properly handles:
  - Invalid cog names
  - ExtensionNotFound
  - ExtensionFailed
  - ExtensionNotLoaded
  
   What I Learned During Implementation:
- How Discord Hybrid Commands work (prefix + slash support)
- How slash command syncing works using `self.tree.sync()`
- How to properly handle extension reloading errors

🛡 Development Workflow:

- Created a separate feature branch: `issue7-cogs`
- Implemented and tested the feature safely
- Ensured slash and prefix commands both work correctly
- Prepared for merge request submission
🚀 A merge request has been created and is ready for review.

Please let me know if any improvements or adjustments are required.