### PR TITLE
feat: adding ByteBotHQ Role

### DIFF
--- a/byte_bot/__main__.py
+++ b/byte_bot/__main__.py
@@ -13,8 +13,13 @@ log = logging.getLogger(__name__)
 def get_config() -> Config:
     discord_token = os.environ.get("DISCORD_TOKEN")
     forum_channel_id_str = os.environ.get("FEATURE_FORUM_CHANNEL_ID")
+
     # Keep a local sqlite file by default so the bot can start without extra setup.
-    database_path = os.environ.get("DATABASE_PATH") or str(Path(__file__).resolve().parents[1] / "database" /"byte_bot.db")
+    database_path = os.environ.get("DATABASE_PATH") or str(
+        Path(__file__).resolve().parents[1] / "database" / "byte_bot.db"
+    )
+
+    role_channel_id_str = os.environ.get("ROLE_CHANNEL_ID")
 
     if not discord_token:  # Ensure the token is set before proceeding
         raise ValueError("DISCORD_TOKEN environment variable is not set.")
@@ -26,10 +31,18 @@ def get_config() -> Config:
     except ValueError:
         raise ValueError("FEATURE_FORUM_CHANNEL_ID must be an integer.")
     
+    role_channel_id = None
+    if role_channel_id_str:
+        try:
+            role_channel_id = int(role_channel_id_str)
+        except ValueError:
+            raise ValueError("ROLE_CHANNEL_ID must be an integer.")
+
     return Config(
         DISCORD_TOKEN=discord_token,
         FEATURE_FORUM_CHANNEL_ID=forum_channel_id,
         DATABASE_PATH=database_path,
+        ROLE_CHANNEL_ID=role_channel_id,
     )
 
 def main():

--- a/byte_bot/cogs/role_toggle.py
+++ b/byte_bot/cogs/role_toggle.py
@@ -71,8 +71,10 @@ class RoleToggleCog(commands.Cog):
         await self._setup_role_toggle_panels(channel.guild, channel)
 
     async def _setup_role_toggle_panels(self, guild: discord.Guild, channel: discord.TextChannel) -> None:
+        existing_panels = self.service.list_panels(guild.id)
+
         # Keep the default panel around.
-        if self.service.get_panel(guild.id, role_name=DEFAULT_ROLE_NAME) is None:
+        if not any(panel.role_name == DEFAULT_ROLE_NAME for panel in existing_panels):
             try:
                 await self._create_panel(
                     guild=guild,
@@ -86,7 +88,7 @@ class RoleToggleCog(commands.Cog):
             except Exception:
                 log.exception("Failed to create default role-toggle panel in guild '%s'", guild.name)
 
-        for panel in self.service.list_panels(guild.id):
+        for panel in existing_panels:
             try:
                 await self._update_existing_panel(guild, channel, panel)
             except discord.Forbidden:
@@ -129,6 +131,21 @@ class RoleToggleCog(commands.Cog):
         role = await guild.create_role(name=role_name, mentionable=True)
         log.info("Created role '%s' in guild '%s'", role_name, guild.name)
         return role
+
+    async def _resolve_panel_role(self, guild: discord.Guild, panel: RoleTogglePanel) -> discord.Role:
+        if panel.role_id is not None:
+            role = guild.get_role(panel.role_id)
+            if role is not None:
+                return role
+
+            log.warning(
+                "Stored Discord role id %s for panel '%s' was not found in guild '%s'; recreating/rebinding role",
+                panel.role_id,
+                panel.role_name,
+                guild.name,
+            )
+
+        return await self._create_panel_role(guild, panel.role_name)
 
     def _get_panel_role(self, guild: discord.Guild, panel: RoleTogglePanel) -> discord.Role | None:
         if panel.role_id is None:
@@ -194,9 +211,16 @@ class RoleToggleCog(commands.Cog):
     async def _update_existing_panel(
         self, guild: discord.Guild, channel: discord.TextChannel, panel: RoleTogglePanel
     ) -> bool:
-        role = self._get_panel_role(guild, panel)
-        if role is None:
-            return False
+        role = await self._resolve_panel_role(guild, panel)
+        if panel.role_id != role.id:
+            panel = self.service.upsert_panel(
+                guild_id=panel.guild_id,
+                role_name=panel.role_name,
+                emoji=panel.emoji,
+                title=panel.title,
+                message_id=panel.message_id,
+                role_id=role.id,
+            )
 
         if panel.message_id is None:
             log.warning("Role-toggle panel '%s' has no stored Discord message id", panel.role_name)
@@ -313,19 +337,18 @@ class RoleToggleCog(commands.Cog):
                     title=effective_title,
                 )
             else:
+                role = await self._resolve_panel_role(ctx.guild, existing_panel)
                 panel = RoleTogglePanel(
                     guild_id=ctx.guild.id,
                     message_id=existing_panel.message_id,
-                    role_id=existing_panel.role_id,
+                    role_id=role.id,
                     role_name=cleaned_role_name,
                     emoji=cleaned_emoji,
                     title=effective_title,
                 )
                 updated = await self._update_existing_panel(ctx.guild, channel, panel)
                 if not updated:
-                    await self._reply(
-                        ctx, "Could not update that role-toggle panel because its Discord objects are missing."
-                    )
+                    await self._reply(ctx, "Could not update that role-toggle panel because its message is missing.")
                     return
                 panel = self.service.upsert_panel(
                     guild_id=ctx.guild.id,

--- a/byte_bot/cogs/role_toggle.py
+++ b/byte_bot/cogs/role_toggle.py
@@ -1,17 +1,22 @@
 import logging
+import re
 
 import discord
 from discord.ext import commands
 from discord import app_commands
 
+from byte_bot.byte_bot import ByteBot
 from byte_bot.services.role_toggle_service import (
     DEFAULT_ROLE_NAME,
     DEFAULT_TOGGLE_EMOJI,
     DEFAULT_TOGGLE_TITLE,
+    RoleTogglePanel,
     RoleToggleService,
 )
 
 log = logging.getLogger(__name__)
+
+CUSTOM_EMOJI_PATTERN = re.compile(r"<a?:[A-Za-z0-9_]{2,32}:[0-9]{17,20}>")
 
 
 def _build_role_toggle_embed(*, title: str, role_name: str, emoji: str) -> discord.Embed:
@@ -28,7 +33,7 @@ def _build_role_toggle_embed(*, title: str, role_name: str, emoji: str) -> disco
 
 
 class RoleToggleCog(commands.Cog):
-    def __init__(self, bot):
+    def __init__(self, bot: ByteBot):
         self.bot = bot
         self.service = RoleToggleService(bot.database_service)
         self._setup_complete = False
@@ -58,24 +63,32 @@ class RoleToggleCog(commands.Cog):
 
         channel = await self._get_text_channel(self._role_channel_id)
         if channel is None:
-            log.warning("ROLE_CHANNEL_ID %s is not a usable text channel; skipping role-toggle setup", self._role_channel_id)
+            log.warning(
+                "ROLE_CHANNEL_ID %s is not a usable text channel; skipping role-toggle setup", self._role_channel_id
+            )
             return
 
-        await self._ensure_all_panels(channel.guild, channel)
+        await self._setup_role_toggle_panels(channel.guild, channel)
 
-    async def _ensure_all_panels(self, guild: discord.Guild, channel: discord.TextChannel) -> None:
+    async def _setup_role_toggle_panels(self, guild: discord.Guild, channel: discord.TextChannel) -> None:
         # Keep the default panel around.
         if self.service.get_panel(guild.id, role_name=DEFAULT_ROLE_NAME) is None:
-            self.service.upsert_panel(
-                guild_id=guild.id,
-                role_name=DEFAULT_ROLE_NAME,
-                emoji=DEFAULT_TOGGLE_EMOJI,
-                title=DEFAULT_TOGGLE_TITLE,
-            )
+            try:
+                await self._create_panel(
+                    guild=guild,
+                    channel=channel,
+                    role_name=DEFAULT_ROLE_NAME,
+                    emoji=DEFAULT_TOGGLE_EMOJI,
+                    title=DEFAULT_TOGGLE_TITLE,
+                )
+            except discord.Forbidden:
+                log.error("Missing permissions to create default role-toggle panel in guild '%s'", guild.name)
+            except Exception:
+                log.exception("Failed to create default role-toggle panel in guild '%s'", guild.name)
 
         for panel in self.service.list_panels(guild.id):
             try:
-                await self._ensure_panel(guild, channel, panel)
+                await self._update_existing_panel(guild, channel, panel)
             except discord.Forbidden:
                 log.error("Missing permissions to set up role-toggle panel in guild '%s'", guild.name)
             except Exception:
@@ -93,39 +106,128 @@ class RoleToggleCog(commands.Cog):
             return channel
         return None
 
-    async def _ensure_panel(self, guild: discord.Guild, channel: discord.TextChannel, panel) -> None:
-        role = await self.service.ensure_role(guild, panel.role_name)
+    async def _fetch_guild(self, guild_id: int) -> discord.Guild | None:
+        guild = self.bot.get_guild(guild_id)
+        if guild is not None:
+            return guild
+
+        try:
+            return await self.bot.fetch_guild(guild_id)
+        except discord.NotFound:
+            log.warning("Guild %s was not found while handling a role-toggle reaction", guild_id)
+        except discord.HTTPException:
+            log.exception("Failed to fetch guild %s while handling a role-toggle reaction", guild_id)
+        return None
+
+    async def _create_panel_role(self, guild: discord.Guild, role_name: str) -> discord.Role:
+        matching_roles = [role for role in guild.roles if role.name == role_name]
+        if len(matching_roles) > 1:
+            raise ValueError(f"Multiple Discord roles named '{role_name}' already exist.")
+        if matching_roles:
+            return matching_roles[0]
+
+        role = await guild.create_role(name=role_name, mentionable=True)
+        log.info("Created role '%s' in guild '%s'", role_name, guild.name)
+        return role
+
+    def _get_panel_role(self, guild: discord.Guild, panel: RoleTogglePanel) -> discord.Role | None:
+        if panel.role_id is None:
+            log.warning("Role-toggle panel '%s' has no stored Discord role id", panel.role_name)
+            return None
+
+        role = guild.get_role(panel.role_id)
+        if role is None:
+            log.warning(
+                "Stored Discord role id %s for panel '%s' was not found in guild '%s'",
+                panel.role_id,
+                panel.role_name,
+                guild.name,
+            )
+        return role
+
+    def _validate_role_name(self, guild: discord.Guild, role_name: str) -> str | None:
+        if not role_name:
+            return "Role name cannot be empty."
+        if role_name in {"@everyone", "everyone"}:
+            return "`@everyone` cannot be used as a role-toggle role."
+        if len(role_name) > 100:
+            return "Role name must be 100 characters or fewer."
+
+        matching_roles = [role for role in guild.roles if role.name == role_name]
+        if len(matching_roles) > 1:
+            return f"Multiple Discord roles named `{role_name}` already exist. Please rename one before using this command."
+        return None
+
+    def _validate_emoji(self, emoji: str) -> str | None:
+        if not emoji:
+            return "Emoji cannot be empty."
+        if CUSTOM_EMOJI_PATTERN.fullmatch(emoji):
+            return None
+        if any(character.isspace() for character in emoji):
+            return "Emoji cannot contain whitespace."
+        if len(emoji) > 32:
+            return "Emoji must be 32 characters or fewer."
+        if emoji.isascii():
+            return (
+                "Emoji must be a Unicode emoji or a Discord custom emoji like `<:name:id>`. "
+                "For prefix commands with multi-word role names, wrap the role name in quotes."
+            )
+        return None
+
+    async def _create_panel(
+        self, *, guild: discord.Guild, channel: discord.TextChannel, role_name: str, emoji: str, title: str
+    ) -> RoleTogglePanel:
+        role = await self._create_panel_role(guild, role_name)
+        embed = _build_role_toggle_embed(title=title, role_name=role.name, emoji=emoji)
+        message = await channel.send(embed=embed)
+        await message.add_reaction(emoji)
+
+        return self.service.upsert_panel(
+            guild_id=guild.id,
+            role_name=role_name,
+            emoji=emoji,
+            title=title,
+            message_id=message.id,
+            role_id=role.id,
+        )
+
+    async def _update_existing_panel(
+        self, guild: discord.Guild, channel: discord.TextChannel, panel: RoleTogglePanel
+    ) -> bool:
+        role = self._get_panel_role(guild, panel)
+        if role is None:
+            return False
+
+        if panel.message_id is None:
+            log.warning("Role-toggle panel '%s' has no stored Discord message id", panel.role_name)
+            return False
+
         embed = _build_role_toggle_embed(title=panel.title, role_name=role.name, emoji=panel.emoji)
 
-        message = None
-        if panel.message_id:
-            try:
-                message = await channel.fetch_message(panel.message_id)
-            except discord.NotFound:
-                # Panel message was deleted; we'll recreate it.
-                self.service.set_message_id(guild_id=panel.guild_id, role_name=panel.role_name, message_id=None)
-                message = None
-            except discord.Forbidden:
-                # Can't read message history; don't risk posting duplicates.
-                log.error("Forbidden fetching role-toggle message %s in #%s", panel.message_id, channel.name)
-                return
-            except discord.HTTPException:
-                log.exception("HTTP error fetching role-toggle message %s in #%s", panel.message_id, channel.name)
-                return
+        try:
+            message = await channel.fetch_message(panel.message_id)
+        except discord.NotFound:
+            log.warning("Stored role-toggle message %s for panel '%s' was not found", panel.message_id, panel.role_name)
+            return False
+        except discord.Forbidden:
+            log.error("Forbidden fetching role-toggle message %s in #%s", panel.message_id, channel.name)
+            return False
+        except discord.HTTPException:
+            log.exception("HTTP error fetching role-toggle message %s in #%s", panel.message_id, channel.name)
+            return False
 
-        if message is None:
-            message = await channel.send(embed=embed)
-            self.service.set_message_id(guild_id=panel.guild_id, role_name=panel.role_name, message_id=message.id)
-
-        else:
-            await message.edit(embed=embed)
-
+        await message.edit(embed=embed)
         try:
             await message.add_reaction(panel.emoji)
         except discord.HTTPException:
-            log.warning("Could not add reaction %s to role-toggle message %s", panel.emoji, message.id)
+            log.exception("Could not add reaction %s to role-toggle message %s", panel.emoji, message.id)
+            raise
 
-    @commands.hybrid_command(name="roletoggle_status", description="Show the role-toggle configuration for this server.")
+        return True
+
+    @commands.hybrid_command(
+        name="roletoggle_status", description="Show the role-toggle configuration for this server."
+    )
     async def role_toggle_status(self, ctx: commands.Context) -> None:
         if ctx.guild is None:
             await self._reply(ctx, "This command can only be used in a server.")
@@ -143,7 +245,9 @@ class RoleToggleCog(commands.Cog):
             f"Role-toggle channel: <#{self._role_channel_id}>. Panels: {len(panels)}. Default: `{default_name}`.",
         )
 
-    @commands.hybrid_command(name="roletoggle_list", description="List all role-toggle panels configured for this server.")
+    @commands.hybrid_command(
+        name="roletoggle_list", description="List all role-toggle panels configured for this server."
+    )
     async def role_toggle_list(self, ctx: commands.Context) -> None:
         if ctx.guild is None:
             await self._reply(ctx, "This command can only be used in a server.")
@@ -154,10 +258,7 @@ class RoleToggleCog(commands.Cog):
             await self._reply(ctx, "No role-toggle panels are configured for this server.")
             return
 
-        lines = [
-            f"- `{p.role_name}` (emoji {p.emoji})"
-            for p in panels
-        ]
+        lines = [f"- `{p.role_name}` (emoji {p.emoji})" for p in panels]
         await self._reply(ctx, "Role-toggle panels:\n" + "\n".join(lines))
 
     @commands.hybrid_command(name="roletoggle_add", description="Add a new role-toggle panel for this server.")
@@ -183,23 +284,68 @@ class RoleToggleCog(commands.Cog):
             return
 
         cleaned_role_name = role_name.strip()
-        if not cleaned_role_name:
-            await self._reply(ctx, "Role name cannot be empty.")
+        role_name_error = self._validate_role_name(ctx.guild, cleaned_role_name)
+        if role_name_error is not None:
+            await self._reply(ctx, role_name_error)
+            return
+
+        cleaned_emoji = emoji.strip()
+        emoji_error = self._validate_emoji(cleaned_emoji)
+        if emoji_error is not None:
+            await self._reply(ctx, emoji_error)
             return
 
         effective_title = title.strip() if title and title.strip() else f"{cleaned_role_name} Access"
 
-        self.service.upsert_panel(
-            guild_id=ctx.guild.id,
-            role_name=cleaned_role_name,
-            emoji=emoji,
-            title=effective_title,
-        )
-        await self._reply(ctx, f"Added role-toggle panel for role `{cleaned_role_name}`.")
-
         channel = await self._get_text_channel(self._role_channel_id)
-        if channel is not None:
-            await self._ensure_all_panels(ctx.guild, channel)
+        if channel is None:
+            await self._reply(ctx, "ROLE_CHANNEL_ID is not a usable text channel. Panel was not saved.")
+            return
+
+        try:
+            existing_panel = self.service.get_panel(ctx.guild.id, role_name=cleaned_role_name)
+            if existing_panel is None:
+                panel = await self._create_panel(
+                    guild=ctx.guild,
+                    channel=channel,
+                    role_name=cleaned_role_name,
+                    emoji=cleaned_emoji,
+                    title=effective_title,
+                )
+            else:
+                panel = RoleTogglePanel(
+                    guild_id=ctx.guild.id,
+                    message_id=existing_panel.message_id,
+                    role_id=existing_panel.role_id,
+                    role_name=cleaned_role_name,
+                    emoji=cleaned_emoji,
+                    title=effective_title,
+                )
+                updated = await self._update_existing_panel(ctx.guild, channel, panel)
+                if not updated:
+                    await self._reply(
+                        ctx, "Could not update that role-toggle panel because its Discord objects are missing."
+                    )
+                    return
+                panel = self.service.upsert_panel(
+                    guild_id=ctx.guild.id,
+                    role_name=cleaned_role_name,
+                    emoji=cleaned_emoji,
+                    title=effective_title,
+                    message_id=panel.message_id,
+                    role_id=panel.role_id,
+                )
+        except ValueError as error:
+            await self._reply(ctx, str(error))
+            return
+        except discord.Forbidden:
+            await self._reply(ctx, "I do not have permission to create/update that role-toggle panel.")
+            return
+        except discord.HTTPException:
+            await self._reply(ctx, "Discord rejected the role-toggle panel update. Check the emoji and my permissions.")
+            return
+
+        await self._reply(ctx, f"Saved role-toggle panel for role `{panel.role_name}`.")
 
     @role_toggle_add.error
     async def role_toggle_add_error(self, ctx: commands.Context, error: Exception) -> None:
@@ -208,13 +354,17 @@ class RoleToggleCog(commands.Cog):
             return
         raise error
 
-    @commands.hybrid_command(name="roletoggle_delete", description="Delete a role-toggle panel (removes the panel message). Optionally also delete / preserve the Discord role")
+    @commands.hybrid_command(
+        name="roletoggle_delete", description="Delete a role-toggle panel and optionally delete its Discord role."
+    )
     @app_commands.describe(
         role_name="Role name of the panel to delete (use /roletoggle_list)",
         delete_discord_role="Also delete the Discord role (only if you really want it gone)",
     )
     @commands.has_permissions(manage_guild=True)
-    async def role_toggle_delete(self, ctx: commands.Context, role_name: str, delete_discord_role: bool = True) -> None:
+    async def role_toggle_delete(
+        self, ctx: commands.Context, role_name: str, delete_discord_role: bool = False
+    ) -> None:
         if ctx.guild is None:
             await self._reply(ctx, "This command can only be used in a server.")
             return
@@ -239,7 +389,7 @@ class RoleToggleCog(commands.Cog):
 
         if delete_discord_role:
             # This deletes the real Discord role (removes it from everyone).
-            role = discord.utils.get(ctx.guild.roles, name=panel.role_name)
+            role = self._get_panel_role(ctx.guild, panel)
             if role is not None:
                 try:
                     await role.delete(reason="Role-toggle deleted by admin")
@@ -259,11 +409,11 @@ class RoleToggleCog(commands.Cog):
         raise error
 
     async def _toggle_role_for_member(
-        self, *, guild: discord.Guild, user_id: int, role_name: str, should_have_role: bool
+        self, *, guild: discord.Guild, user_id: int, panel: RoleTogglePanel, should_have_role: bool
     ) -> None:
-        role = discord.utils.get(guild.roles, name=role_name)
+        role = self._get_panel_role(guild, panel)
         if role is None:
-            log.warning("Role '%s' does not exist in guild '%s'", role_name, guild.name)
+            log.warning("Role '%s' does not exist in guild '%s'", panel.role_name, guild.name)
             return
 
         member = guild.get_member(user_id)
@@ -299,14 +449,12 @@ class RoleToggleCog(commands.Cog):
         if panel is None:
             return
 
-        guild = self.bot.get_guild(payload.guild_id)
+        guild = await self._fetch_guild(payload.guild_id)
         if guild is None:
             return
 
         try:
-            await self._toggle_role_for_member(
-                guild=guild, user_id=payload.user_id, role_name=panel.role_name, should_have_role=True
-            )
+            await self._toggle_role_for_member(guild=guild, user_id=payload.user_id, panel=panel, should_have_role=True)
         except discord.Forbidden:
             log.error("Missing permissions to add '%s' via reactions", panel.role_name)
         except Exception:
@@ -329,13 +477,13 @@ class RoleToggleCog(commands.Cog):
         if panel is None:
             return
 
-        guild = self.bot.get_guild(payload.guild_id)
+        guild = await self._fetch_guild(payload.guild_id)
         if guild is None:
             return
 
         try:
             await self._toggle_role_for_member(
-                guild=guild, user_id=payload.user_id, role_name=panel.role_name, should_have_role=False
+                guild=guild, user_id=payload.user_id, panel=panel, should_have_role=False
             )
         except discord.Forbidden:
             log.error("Missing permissions to remove '%s' via reactions", panel.role_name)
@@ -343,5 +491,5 @@ class RoleToggleCog(commands.Cog):
             log.exception("Failed to remove '%s' via reaction", panel.role_name)
 
 
-async def setup(bot: commands.Bot) -> None:
+async def setup(bot: ByteBot) -> None:
     await bot.add_cog(RoleToggleCog(bot))

--- a/byte_bot/cogs/role_toggle.py
+++ b/byte_bot/cogs/role_toggle.py
@@ -208,7 +208,7 @@ class RoleToggleCog(commands.Cog):
             return
         raise error
 
-    @commands.hybrid_command(name="roletoggle_delete", description="Delete a role-toggle panel configuration.")
+    @commands.hybrid_command(name="roletoggle_delete", description="Delete a role-toggle panel (removes the panel message). Optionally also delete / preserve the Discord role")
     @app_commands.describe(
         role_name="Role name of the panel to delete (use /roletoggle_list)",
         delete_discord_role="Also delete the Discord role (only if you really want it gone)",

--- a/byte_bot/cogs/role_toggle.py
+++ b/byte_bot/cogs/role_toggle.py
@@ -1,0 +1,347 @@
+import logging
+
+import discord
+from discord.ext import commands
+from discord import app_commands
+
+from byte_bot.services.role_toggle_service import (
+    DEFAULT_ROLE_NAME,
+    DEFAULT_TOGGLE_EMOJI,
+    DEFAULT_TOGGLE_TITLE,
+    RoleToggleService,
+)
+
+log = logging.getLogger(__name__)
+
+
+def _build_role_toggle_embed(*, title: str, role_name: str, emoji: str) -> discord.Embed:
+    description = (
+        f"Welcome to {role_name}.\n\n"
+        "Use the reaction below to toggle access to the community role.\n"
+        f"{emoji} {role_name}\n\n"
+        "Add your reaction to join.\n"
+        "Remove your reaction to leave."
+    )
+    embed = discord.Embed(title=title, description=description, color=discord.Color.blue())
+    embed.set_footer(text="Reaction role panel")
+    return embed
+
+
+class RoleToggleCog(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+        self.service = RoleToggleService(bot.database_service)
+        self._setup_complete = False
+        self._role_channel_id: int | None = None
+
+    async def _reply(self, ctx: commands.Context, message: str) -> None:
+        if ctx.interaction:
+            try:
+                await ctx.interaction.response.send_message(message, ephemeral=True)
+            except discord.InteractionResponded:
+                await ctx.interaction.followup.send(message, ephemeral=True)
+        else:
+            await ctx.send(message)
+
+    @commands.Cog.listener()
+    async def on_ready(self) -> None:
+        # on_ready can fire more than once (reconnects).
+        if self._setup_complete:
+            return
+        self._setup_complete = True
+
+        # One channel for all panels, configured via env.
+        self._role_channel_id = getattr(self.bot.config, "ROLE_CHANNEL_ID", None)
+        if not self._role_channel_id:
+            log.info("ROLE_CHANNEL_ID not set; skipping role-toggle setup")
+            return
+
+        channel = await self._get_text_channel(self._role_channel_id)
+        if channel is None:
+            log.warning("ROLE_CHANNEL_ID %s is not a usable text channel; skipping role-toggle setup", self._role_channel_id)
+            return
+
+        await self._ensure_all_panels(channel.guild, channel)
+
+    async def _ensure_all_panels(self, guild: discord.Guild, channel: discord.TextChannel) -> None:
+        # Keep the default panel around.
+        if self.service.get_panel(guild.id, role_name=DEFAULT_ROLE_NAME) is None:
+            self.service.upsert_panel(
+                guild_id=guild.id,
+                role_name=DEFAULT_ROLE_NAME,
+                emoji=DEFAULT_TOGGLE_EMOJI,
+                title=DEFAULT_TOGGLE_TITLE,
+            )
+
+        for panel in self.service.list_panels(guild.id):
+            try:
+                await self._ensure_panel(guild, channel, panel)
+            except discord.Forbidden:
+                log.error("Missing permissions to set up role-toggle panel in guild '%s'", guild.name)
+            except Exception:
+                log.exception("Failed to set up role-toggle panel in guild '%s'", guild.name)
+
+    async def _get_text_channel(self, channel_id: int) -> discord.TextChannel | None:
+        channel = self.bot.get_channel(channel_id)
+        if channel is None:
+            try:
+                channel = await self.bot.fetch_channel(channel_id)
+            except discord.HTTPException:
+                return None
+
+        if isinstance(channel, discord.TextChannel):
+            return channel
+        return None
+
+    async def _ensure_panel(self, guild: discord.Guild, channel: discord.TextChannel, panel) -> None:
+        role = await self.service.ensure_role(guild, panel.role_name)
+        embed = _build_role_toggle_embed(title=panel.title, role_name=role.name, emoji=panel.emoji)
+
+        message = None
+        if panel.message_id:
+            try:
+                message = await channel.fetch_message(panel.message_id)
+            except discord.NotFound:
+                # Panel message was deleted; we'll recreate it.
+                self.service.set_message_id(guild_id=panel.guild_id, role_name=panel.role_name, message_id=None)
+                message = None
+            except discord.Forbidden:
+                # Can't read message history; don't risk posting duplicates.
+                log.error("Forbidden fetching role-toggle message %s in #%s", panel.message_id, channel.name)
+                return
+            except discord.HTTPException:
+                log.exception("HTTP error fetching role-toggle message %s in #%s", panel.message_id, channel.name)
+                return
+
+        if message is None:
+            message = await channel.send(embed=embed)
+            self.service.set_message_id(guild_id=panel.guild_id, role_name=panel.role_name, message_id=message.id)
+
+        else:
+            await message.edit(embed=embed)
+
+        try:
+            await message.add_reaction(panel.emoji)
+        except discord.HTTPException:
+            log.warning("Could not add reaction %s to role-toggle message %s", panel.emoji, message.id)
+
+    @commands.hybrid_command(name="roletoggle_status", description="Show the role-toggle configuration for this server.")
+    async def role_toggle_status(self, ctx: commands.Context) -> None:
+        if ctx.guild is None:
+            await self._reply(ctx, "This command can only be used in a server.")
+            return
+
+        if not self._role_channel_id:
+            await self._reply(ctx, "ROLE_CHANNEL_ID is not set. Role toggles are disabled.")
+            return
+
+        panels = self.service.list_panels(ctx.guild.id)
+        default_panel = self.service.get_panel(ctx.guild.id, role_name=DEFAULT_ROLE_NAME)
+        default_name = default_panel.role_name if default_panel else DEFAULT_ROLE_NAME
+        await self._reply(
+            ctx,
+            f"Role-toggle channel: <#{self._role_channel_id}>. Panels: {len(panels)}. Default: `{default_name}`.",
+        )
+
+    @commands.hybrid_command(name="roletoggle_list", description="List all role-toggle panels configured for this server.")
+    async def role_toggle_list(self, ctx: commands.Context) -> None:
+        if ctx.guild is None:
+            await self._reply(ctx, "This command can only be used in a server.")
+            return
+
+        panels = self.service.list_panels(ctx.guild.id)
+        if not panels:
+            await self._reply(ctx, "No role-toggle panels are configured for this server.")
+            return
+
+        lines = [
+            f"- `{p.role_name}` (emoji {p.emoji})"
+            for p in panels
+        ]
+        await self._reply(ctx, "Role-toggle panels:\n" + "\n".join(lines))
+
+    @commands.hybrid_command(name="roletoggle_add", description="Add a new role-toggle panel for this server.")
+    @app_commands.describe(
+        role_name="Discord role name to create/use.",
+        emoji="Emoji users react with to toggle the role (defaults to ✅).",
+        title="Embed title (defaults to '<role name> Access').",
+    )
+    @commands.has_permissions(manage_guild=True)
+    async def role_toggle_add(
+        self,
+        ctx: commands.Context,
+        role_name: str,
+        emoji: str = DEFAULT_TOGGLE_EMOJI,
+        title: str | None = None,
+    ) -> None:
+        if ctx.guild is None:
+            await self._reply(ctx, "This command can only be used in a server.")
+            return
+
+        if not self._role_channel_id:
+            await self._reply(ctx, "ROLE_CHANNEL_ID is not set. Role toggles are disabled.")
+            return
+
+        cleaned_role_name = role_name.strip()
+        if not cleaned_role_name:
+            await self._reply(ctx, "Role name cannot be empty.")
+            return
+
+        effective_title = title.strip() if title and title.strip() else f"{cleaned_role_name} Access"
+
+        self.service.upsert_panel(
+            guild_id=ctx.guild.id,
+            role_name=cleaned_role_name,
+            emoji=emoji,
+            title=effective_title,
+        )
+        await self._reply(ctx, f"Added role-toggle panel for role `{cleaned_role_name}`.")
+
+        channel = await self._get_text_channel(self._role_channel_id)
+        if channel is not None:
+            await self._ensure_all_panels(ctx.guild, channel)
+
+    @role_toggle_add.error
+    async def role_toggle_add_error(self, ctx: commands.Context, error: Exception) -> None:
+        if isinstance(error, commands.MissingPermissions):
+            await self._reply(ctx, "You need `Manage Server` permissions to do that.")
+            return
+        raise error
+
+    @commands.hybrid_command(name="roletoggle_delete", description="Delete a role-toggle panel configuration.")
+    @app_commands.describe(
+        role_name="Role name of the panel to delete (use /roletoggle_list)",
+        delete_discord_role="Also delete the Discord role (only if you really want it gone)",
+    )
+    @commands.has_permissions(manage_guild=True)
+    async def role_toggle_delete(self, ctx: commands.Context, role_name: str, delete_discord_role: bool = True) -> None:
+        if ctx.guild is None:
+            await self._reply(ctx, "This command can only be used in a server.")
+            return
+
+        cleaned_role_name = role_name.strip()
+        panel = self.service.get_panel(ctx.guild.id, role_name=cleaned_role_name)
+        if panel is None:
+            await self._reply(ctx, f"No role-toggle panel found for role `{cleaned_role_name}`.")
+            return
+
+        channel = await self._get_text_channel(self._role_channel_id) if self._role_channel_id else None
+        if channel is not None and panel.message_id:
+            try:
+                message = await channel.fetch_message(panel.message_id)
+                await message.delete()
+            except discord.Forbidden:
+                pass
+            except discord.NotFound:
+                pass
+            except discord.HTTPException:
+                log.exception("Failed deleting role-toggle message %s", panel.message_id)
+
+        if delete_discord_role:
+            # This deletes the real Discord role (removes it from everyone).
+            role = discord.utils.get(ctx.guild.roles, name=panel.role_name)
+            if role is not None:
+                try:
+                    await role.delete(reason="Role-toggle deleted by admin")
+                except discord.Forbidden:
+                    await self._reply(ctx, "Deleted config, but I don't have permission to delete the Discord role.")
+                except discord.HTTPException:
+                    await self._reply(ctx, "Deleted config, but failed to delete the Discord role (HTTP error).")
+
+        self.service.delete_panel(guild_id=ctx.guild.id, role_name=panel.role_name)
+        await self._reply(ctx, f"Deleted role-toggle panel for role `{panel.role_name}`.")
+
+    @role_toggle_delete.error
+    async def role_toggle_delete_error(self, ctx: commands.Context, error: Exception) -> None:
+        if isinstance(error, commands.MissingPermissions):
+            await self._reply(ctx, "You need `Manage Server` permissions to do that.")
+            return
+        raise error
+
+    async def _toggle_role_for_member(
+        self, *, guild: discord.Guild, user_id: int, role_name: str, should_have_role: bool
+    ) -> None:
+        role = discord.utils.get(guild.roles, name=role_name)
+        if role is None:
+            log.warning("Role '%s' does not exist in guild '%s'", role_name, guild.name)
+            return
+
+        member = guild.get_member(user_id)
+        if member is None:
+            try:
+                member = await guild.fetch_member(user_id)
+            except discord.HTTPException:
+                log.warning("Could not fetch member %s in guild '%s'", user_id, guild.name)
+                return
+
+        has_role = role in member.roles
+        if should_have_role and not has_role:
+            await member.add_roles(role, reason="User reacted to role toggle message")
+        elif not should_have_role and has_role:
+            await member.remove_roles(role, reason="User removed reaction from role toggle message")
+
+    @commands.Cog.listener()
+    async def on_raw_reaction_add(self, payload: discord.RawReactionActionEvent) -> None:
+        if self.bot.user is not None and payload.user_id == self.bot.user.id:
+            return
+        if payload.guild_id is None:
+            return
+
+        # Ignore reactions outside the configured channel.
+        if not self._role_channel_id or payload.channel_id != self._role_channel_id:
+            return
+
+        panel = self.service.find_matching_panel(
+            guild_id=payload.guild_id,
+            message_id=payload.message_id,
+            emoji=str(payload.emoji),
+        )
+        if panel is None:
+            return
+
+        guild = self.bot.get_guild(payload.guild_id)
+        if guild is None:
+            return
+
+        try:
+            await self._toggle_role_for_member(
+                guild=guild, user_id=payload.user_id, role_name=panel.role_name, should_have_role=True
+            )
+        except discord.Forbidden:
+            log.error("Missing permissions to add '%s' via reactions", panel.role_name)
+        except Exception:
+            log.exception("Failed to add '%s' via reaction", panel.role_name)
+
+    @commands.Cog.listener()
+    async def on_raw_reaction_remove(self, payload: discord.RawReactionActionEvent) -> None:
+        if payload.guild_id is None:
+            return
+
+        # Ignore reactions outside the configured channel.
+        if not self._role_channel_id or payload.channel_id != self._role_channel_id:
+            return
+
+        panel = self.service.find_matching_panel(
+            guild_id=payload.guild_id,
+            message_id=payload.message_id,
+            emoji=str(payload.emoji),
+        )
+        if panel is None:
+            return
+
+        guild = self.bot.get_guild(payload.guild_id)
+        if guild is None:
+            return
+
+        try:
+            await self._toggle_role_for_member(
+                guild=guild, user_id=payload.user_id, role_name=panel.role_name, should_have_role=False
+            )
+        except discord.Forbidden:
+            log.error("Missing permissions to remove '%s' via reactions", panel.role_name)
+        except Exception:
+            log.exception("Failed to remove '%s' via reaction", panel.role_name)
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(RoleToggleCog(bot))

--- a/byte_bot/config.py
+++ b/byte_bot/config.py
@@ -1,8 +1,9 @@
 from dataclasses import dataclass
+from typing import Optional
 
 @dataclass
 class Config:
     DISCORD_TOKEN: str
     FEATURE_FORUM_CHANNEL_ID: int
     DATABASE_PATH: str
-    
+    ROLE_CHANNEL_ID: Optional[int] = None

--- a/byte_bot/services/database_service.py
+++ b/byte_bot/services/database_service.py
@@ -55,6 +55,7 @@ class DatabaseService:
                     CREATE TABLE IF NOT EXISTS role_toggle_panels (
                         guild_id INTEGER NOT NULL,
                         message_id INTEGER,
+                        role_id INTEGER,
                         role_name TEXT NOT NULL,
                         emoji TEXT NOT NULL,
                         title TEXT NOT NULL,

--- a/byte_bot/services/database_service.py
+++ b/byte_bot/services/database_service.py
@@ -50,6 +50,26 @@ class DatabaseService:
                     """
                 )
 
+                connection.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS role_toggle_panels (
+                        guild_id INTEGER NOT NULL,
+                        message_id INTEGER,
+                        role_name TEXT NOT NULL,
+                        emoji TEXT NOT NULL,
+                        title TEXT NOT NULL,
+                        PRIMARY KEY (guild_id, role_name)
+                    )
+                    """
+                )
+
+                connection.execute(
+                    """
+                    CREATE UNIQUE INDEX IF NOT EXISTS idx_role_toggle_panels_message
+                    ON role_toggle_panels (guild_id, message_id, emoji)
+                    """
+                )
+
     def upsert_user(
         self,
         *,

--- a/byte_bot/services/role_toggle_service.py
+++ b/byte_bot/services/role_toggle_service.py
@@ -1,19 +1,16 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-import logging
-
-import discord
+import sqlite3
 
 from byte_bot.services.database_service import DatabaseService
-
-log = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
 class RoleTogglePanel:
     guild_id: int
     message_id: int | None
+    role_id: int | None
     role_name: str
     emoji: str
     title: str
@@ -28,35 +25,36 @@ class RoleToggleService:
     def __init__(self, database_service: DatabaseService):
         self.database_service = database_service
 
+    @staticmethod
+    def _panel_from_row(row: sqlite3.Row) -> RoleTogglePanel:
+        return RoleTogglePanel(
+            guild_id=row["guild_id"],
+            message_id=row["message_id"],
+            role_id=row["role_id"],
+            role_name=row["role_name"],
+            emoji=row["emoji"],
+            title=row["title"],
+        )
+
     def list_panels(self, guild_id: int) -> list[RoleTogglePanel]:
         with self.database_service.get_connection() as connection:
             rows = connection.execute(
                 """
-                SELECT guild_id, message_id, role_name, emoji, title
+                SELECT guild_id, message_id, role_id, role_name, emoji, title
                 FROM role_toggle_panels
                 WHERE guild_id = ?
                 ORDER BY role_name ASC
-                """
-                ,
+                """,
                 (guild_id,),
             ).fetchall()
 
-        return [
-            RoleTogglePanel(
-                guild_id=row["guild_id"],
-                message_id=row["message_id"],
-                role_name=row["role_name"],
-                emoji=row["emoji"],
-                title=row["title"],
-            )
-            for row in rows
-        ]
+        return [self._panel_from_row(row) for row in rows]
 
     def get_panel(self, guild_id: int, *, role_name: str = DEFAULT_ROLE_NAME) -> RoleTogglePanel | None:
         with self.database_service.get_connection() as connection:
             row = connection.execute(
                 """
-                SELECT guild_id, message_id, role_name, emoji, title
+                SELECT guild_id, message_id, role_id, role_name, emoji, title
                 FROM role_toggle_panels
                 WHERE guild_id = ? AND role_name = ?
                 """,
@@ -66,13 +64,7 @@ class RoleToggleService:
         if row is None:
             return None
 
-        return RoleTogglePanel(
-            guild_id=row["guild_id"],
-            message_id=row["message_id"],
-            role_name=row["role_name"],
-            emoji=row["emoji"],
-            title=row["title"],
-        )
+        return self._panel_from_row(row)
 
     def upsert_panel(
         self,
@@ -82,19 +74,21 @@ class RoleToggleService:
         emoji: str = DEFAULT_TOGGLE_EMOJI,
         title: str = DEFAULT_TOGGLE_TITLE,
         message_id: int | None = None,
+        role_id: int | None = None,
     ) -> RoleTogglePanel:
         with self.database_service.get_connection() as connection:
             with connection:
                 connection.execute(
                     """
-                    INSERT INTO role_toggle_panels (guild_id, message_id, role_name, emoji, title)
-                    VALUES (?, ?, ?, ?, ?)
+                    INSERT INTO role_toggle_panels (guild_id, message_id, role_id, role_name, emoji, title)
+                    VALUES (?, ?, ?, ?, ?, ?)
                     ON CONFLICT(guild_id, role_name) DO UPDATE SET
                         message_id = COALESCE(excluded.message_id, role_toggle_panels.message_id),
+                        role_id = COALESCE(excluded.role_id, role_toggle_panels.role_id),
                         emoji = excluded.emoji,
                         title = excluded.title
                     """,
-                    (guild_id, message_id, role_name, emoji, title),
+                    (guild_id, message_id, role_id, role_name, emoji, title),
                 )
 
         return self.get_panel(guild_id, role_name=role_name)  # type: ignore[return-value]
@@ -110,27 +104,11 @@ class RoleToggleService:
                     (guild_id, role_name),
                 )
 
-    def set_message_id(
-        self, *, guild_id: int, role_name: str, message_id: int | None
-    ) -> None:
-        with self.database_service.get_connection() as connection:
-            with connection:
-                connection.execute(
-                    """
-                    UPDATE role_toggle_panels
-                    SET message_id = ?
-                    WHERE guild_id = ? AND role_name = ?
-                    """,
-                    (message_id, guild_id, role_name),
-                )
-
-    def find_matching_panel(
-        self, *, guild_id: int, message_id: int, emoji: str
-    ) -> RoleTogglePanel | None:
+    def find_matching_panel(self, *, guild_id: int, message_id: int, emoji: str) -> RoleTogglePanel | None:
         with self.database_service.get_connection() as connection:
             row = connection.execute(
                 """
-                SELECT guild_id, message_id, role_name, emoji, title
+                SELECT guild_id, message_id, role_id, role_name, emoji, title
                 FROM role_toggle_panels
                 WHERE guild_id = ? AND message_id = ? AND emoji = ?
                 """,
@@ -140,19 +118,4 @@ class RoleToggleService:
         if row is None:
             return None
 
-        return RoleTogglePanel(
-            guild_id=row["guild_id"],
-            message_id=row["message_id"],
-            role_name=row["role_name"],
-            emoji=row["emoji"],
-            title=row["title"],
-        )
-
-    async def ensure_role(self, guild: discord.Guild, role_name: str) -> discord.Role:
-        role = discord.utils.get(guild.roles, name=role_name)
-        if role is not None:
-            return role
-
-        role = await guild.create_role(name=role_name, mentionable=True)
-        log.info("Created role '%s' in guild '%s'", role_name, guild.name)
-        return role
+        return self._panel_from_row(row)

--- a/byte_bot/services/role_toggle_service.py
+++ b/byte_bot/services/role_toggle_service.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+
+import discord
+
+from byte_bot.services.database_service import DatabaseService
+
+log = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class RoleTogglePanel:
+    guild_id: int
+    message_id: int | None
+    role_name: str
+    emoji: str
+    title: str
+
+
+DEFAULT_ROLE_NAME = "ByteClubHQ"
+DEFAULT_TOGGLE_EMOJI = "\u2705"
+DEFAULT_TOGGLE_TITLE = "ByteClubHQ Access"
+
+
+class RoleToggleService:
+    def __init__(self, database_service: DatabaseService):
+        self.database_service = database_service
+
+    def list_panels(self, guild_id: int) -> list[RoleTogglePanel]:
+        with self.database_service.get_connection() as connection:
+            rows = connection.execute(
+                """
+                SELECT guild_id, message_id, role_name, emoji, title
+                FROM role_toggle_panels
+                WHERE guild_id = ?
+                ORDER BY role_name ASC
+                """
+                ,
+                (guild_id,),
+            ).fetchall()
+
+        return [
+            RoleTogglePanel(
+                guild_id=row["guild_id"],
+                message_id=row["message_id"],
+                role_name=row["role_name"],
+                emoji=row["emoji"],
+                title=row["title"],
+            )
+            for row in rows
+        ]
+
+    def get_panel(self, guild_id: int, *, role_name: str = DEFAULT_ROLE_NAME) -> RoleTogglePanel | None:
+        with self.database_service.get_connection() as connection:
+            row = connection.execute(
+                """
+                SELECT guild_id, message_id, role_name, emoji, title
+                FROM role_toggle_panels
+                WHERE guild_id = ? AND role_name = ?
+                """,
+                (guild_id, role_name),
+            ).fetchone()
+
+        if row is None:
+            return None
+
+        return RoleTogglePanel(
+            guild_id=row["guild_id"],
+            message_id=row["message_id"],
+            role_name=row["role_name"],
+            emoji=row["emoji"],
+            title=row["title"],
+        )
+
+    def upsert_panel(
+        self,
+        *,
+        guild_id: int,
+        role_name: str = DEFAULT_ROLE_NAME,
+        emoji: str = DEFAULT_TOGGLE_EMOJI,
+        title: str = DEFAULT_TOGGLE_TITLE,
+        message_id: int | None = None,
+    ) -> RoleTogglePanel:
+        with self.database_service.get_connection() as connection:
+            with connection:
+                connection.execute(
+                    """
+                    INSERT INTO role_toggle_panels (guild_id, message_id, role_name, emoji, title)
+                    VALUES (?, ?, ?, ?, ?)
+                    ON CONFLICT(guild_id, role_name) DO UPDATE SET
+                        message_id = COALESCE(excluded.message_id, role_toggle_panels.message_id),
+                        emoji = excluded.emoji,
+                        title = excluded.title
+                    """,
+                    (guild_id, message_id, role_name, emoji, title),
+                )
+
+        return self.get_panel(guild_id, role_name=role_name)  # type: ignore[return-value]
+
+    def delete_panel(self, *, guild_id: int, role_name: str) -> None:
+        with self.database_service.get_connection() as connection:
+            with connection:
+                connection.execute(
+                    """
+                    DELETE FROM role_toggle_panels
+                    WHERE guild_id = ? AND role_name = ?
+                    """,
+                    (guild_id, role_name),
+                )
+
+    def set_message_id(
+        self, *, guild_id: int, role_name: str, message_id: int | None
+    ) -> None:
+        with self.database_service.get_connection() as connection:
+            with connection:
+                connection.execute(
+                    """
+                    UPDATE role_toggle_panels
+                    SET message_id = ?
+                    WHERE guild_id = ? AND role_name = ?
+                    """,
+                    (message_id, guild_id, role_name),
+                )
+
+    def find_matching_panel(
+        self, *, guild_id: int, message_id: int, emoji: str
+    ) -> RoleTogglePanel | None:
+        with self.database_service.get_connection() as connection:
+            row = connection.execute(
+                """
+                SELECT guild_id, message_id, role_name, emoji, title
+                FROM role_toggle_panels
+                WHERE guild_id = ? AND message_id = ? AND emoji = ?
+                """,
+                (guild_id, message_id, emoji),
+            ).fetchone()
+
+        if row is None:
+            return None
+
+        return RoleTogglePanel(
+            guild_id=row["guild_id"],
+            message_id=row["message_id"],
+            role_name=row["role_name"],
+            emoji=row["emoji"],
+            title=row["title"],
+        )
+
+    async def ensure_role(self, guild: discord.Guild, role_name: str) -> discord.Role:
+        role = discord.utils.get(guild.roles, name=role_name)
+        if role is not None:
+            return role
+
+        role = await guild.create_role(name=role_name, mentionable=True)
+        log.info("Created role '%s' in guild '%s'", role_name, guild.name)
+        return role

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,5 +3,7 @@ services:
     build: .
     env_file:
       - ".env"
+    volumes:
+      - ./database:/app/database
     environment:
       - DISCORD_TOKEN=${DISCORD_TOKEN}

--- a/example.env
+++ b/example.env
@@ -3,5 +3,5 @@
 DISCORD_TOKEN=
 FEATURE_FORUM_CHANNEL_ID=
 ROLE_CHANNEL_ID=
-# Optional. Defaults to ./database/byte_bot.db
+# Optional. Defaults to ./database/byte_bot.db -- if you change default value.. dont forget to update volumes in docker compose
 DATABASE_PATH=

--- a/example.env
+++ b/example.env
@@ -2,4 +2,6 @@
 # You can run cp example.env .env on the command line or just create the new file in your IDE
 DISCORD_TOKEN=
 FEATURE_FORUM_CHANNEL_ID=
+ROLE_CHANNEL_ID=
+# Optional. Defaults to ./database/byte_bot.db
 DATABASE_PATH=

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,7 @@ async def bot(database_path):
     test_config = SimpleNamespace(
         FEATURE_FORUM_CHANNEL_ID=1234567890,
         DATABASE_PATH=database_path,
+        ROLE_CHANNEL_ID=9876543210,
     )
     bot = ByteBot(config=test_config)
     dpytest.configure(bot)

--- a/tests/unit/test_database_service.py
+++ b/tests/unit/test_database_service.py
@@ -20,6 +20,15 @@ def test_database_service_initializes_users_table(database_path):
     assert table["name"] == "users"
 
 
+def test_database_service_initializes_role_toggle_role_id_column(database_path):
+    database_service = DatabaseService(database_path)
+
+    with database_service.get_connection() as connection:
+        columns = connection.execute("PRAGMA table_info(role_toggle_panels)").fetchall()
+
+    assert "role_id" in {column["name"] for column in columns}
+
+
 def test_database_service_upserts_and_reads_user(database_path):
     database_service = DatabaseService(database_path)
 

--- a/tests/unit/test_role_toggle_cog.py
+++ b/tests/unit/test_role_toggle_cog.py
@@ -1,0 +1,81 @@
+from types import SimpleNamespace
+
+from byte_bot.cogs.role_toggle import RoleToggleCog
+from byte_bot.services.role_toggle_service import RoleTogglePanel
+
+
+def _cog_without_bot() -> RoleToggleCog:
+    return RoleToggleCog.__new__(RoleToggleCog)
+
+
+def test_validate_emoji_accepts_unicode_emoji():
+    cog = _cog_without_bot()
+
+    assert cog._validate_emoji("✅") is None
+
+
+def test_validate_emoji_accepts_custom_emoji():
+    cog = _cog_without_bot()
+
+    assert cog._validate_emoji("<:byteclub:123456789012345678>") is None
+
+
+def test_validate_emoji_rejects_plain_text():
+    cog = _cog_without_bot()
+
+    assert cog._validate_emoji("not-an-emoji") is not None
+
+
+def test_validate_role_name_rejects_everyone_role():
+    cog = _cog_without_bot()
+    guild = SimpleNamespace(roles=[])
+
+    assert cog._validate_role_name(guild, "@everyone") is not None
+
+
+def test_validate_role_name_rejects_duplicate_role_names():
+    cog = _cog_without_bot()
+    guild = SimpleNamespace(roles=[SimpleNamespace(name="ByteClubHQ"), SimpleNamespace(name="ByteClubHQ")])
+
+    assert cog._validate_role_name(guild, "ByteClubHQ") is not None
+
+
+def test_get_panel_role_uses_role_id():
+    cog = _cog_without_bot()
+    expected_role = SimpleNamespace(id=100, name="ByteClubHQ")
+    same_name_role = SimpleNamespace(id=200, name="ByteClubHQ")
+    guild = SimpleNamespace(
+        name="Byte Club",
+        roles=[same_name_role, expected_role],
+        get_role=lambda role_id: expected_role if role_id == expected_role.id else None,
+    )
+    panel = RoleTogglePanel(
+        guild_id=1,
+        message_id=2,
+        role_id=expected_role.id,
+        role_name="ByteClubHQ",
+        emoji="✅",
+        title="ByteClubHQ Access",
+    )
+
+    assert cog._get_panel_role(guild, panel) == expected_role
+
+
+def test_get_panel_role_requires_stored_role_id():
+    cog = _cog_without_bot()
+    matching_role = SimpleNamespace(id=100, name="ByteClubHQ")
+    guild = SimpleNamespace(
+        name="Byte Club",
+        roles=[matching_role],
+        get_role=lambda role_id: matching_role if role_id == matching_role.id else None,
+    )
+    panel = RoleTogglePanel(
+        guild_id=1,
+        message_id=2,
+        role_id=None,
+        role_name="ByteClubHQ",
+        emoji="✅",
+        title="ByteClubHQ Access",
+    )
+
+    assert cog._get_panel_role(guild, panel) is None

--- a/tests/unit/test_role_toggle_cog.py
+++ b/tests/unit/test_role_toggle_cog.py
@@ -1,5 +1,7 @@
 from types import SimpleNamespace
 
+import pytest
+
 from byte_bot.cogs.role_toggle import RoleToggleCog
 from byte_bot.services.role_toggle_service import RoleTogglePanel
 
@@ -79,3 +81,106 @@ def test_get_panel_role_requires_stored_role_id():
     )
 
     assert cog._get_panel_role(guild, panel) is None
+
+
+@pytest.mark.asyncio
+async def test_setup_role_toggle_panels_does_not_update_new_default_panel():
+    cog = _cog_without_bot()
+    created = []
+    updated = []
+
+    async def create_panel(**kwargs):
+        created.append(kwargs)
+
+    async def update_existing_panel(guild, channel, panel):
+        updated.append(panel)
+
+    cog.service = SimpleNamespace(list_panels=lambda guild_id: [])
+    cog._create_panel = create_panel
+    cog._update_existing_panel = update_existing_panel
+    guild = SimpleNamespace(id=1, name="Byte Club")
+    channel = SimpleNamespace()
+
+    await cog._setup_role_toggle_panels(guild, channel)
+
+    assert len(created) == 1
+    assert updated == []
+
+
+@pytest.mark.asyncio
+async def test_resolve_panel_role_recreates_missing_stored_role():
+    cog = _cog_without_bot()
+    created_role = SimpleNamespace(id=200, name="ByteClubHQ")
+
+    async def create_role(name: str, mentionable: bool):
+        assert name == "ByteClubHQ"
+        assert mentionable is True
+        return created_role
+
+    guild = SimpleNamespace(
+        name="Byte Club",
+        roles=[],
+        get_role=lambda role_id: None,
+        create_role=create_role,
+    )
+    panel = RoleTogglePanel(
+        guild_id=1,
+        message_id=2,
+        role_id=100,
+        role_name="ByteClubHQ",
+        emoji="✅",
+        title="ByteClubHQ Access",
+    )
+
+    assert await cog._resolve_panel_role(guild, panel) == created_role
+
+
+@pytest.mark.asyncio
+async def test_update_existing_panel_refreshes_missing_role_id():
+    cog = _cog_without_bot()
+    created_role = SimpleNamespace(id=200, name="ByteClubHQ")
+    edited_messages = []
+    reactions = []
+    upserted = []
+
+    async def create_role(name: str, mentionable: bool):
+        assert name == "ByteClubHQ"
+        assert mentionable is True
+        return created_role
+
+    async def edit_message(**kwargs):
+        edited_messages.append(kwargs)
+
+    async def add_reaction(emoji: str):
+        reactions.append(emoji)
+
+    async def fetch_message(message_id: int):
+        assert message_id == 2
+        return SimpleNamespace(id=2, edit=edit_message, add_reaction=add_reaction)
+
+    def upsert_panel(**kwargs):
+        upserted.append(kwargs)
+        return RoleTogglePanel(**kwargs)
+
+    cog.service = SimpleNamespace(upsert_panel=upsert_panel)
+    guild = SimpleNamespace(
+        id=1,
+        name="Byte Club",
+        roles=[],
+        get_role=lambda role_id: None,
+        create_role=create_role,
+    )
+    channel = SimpleNamespace(name="roles", fetch_message=fetch_message)
+    panel = RoleTogglePanel(
+        guild_id=1,
+        message_id=2,
+        role_id=100,
+        role_name="ByteClubHQ",
+        emoji="✅",
+        title="ByteClubHQ Access",
+    )
+
+    assert await cog._update_existing_panel(guild, channel, panel) is True
+    assert upserted[0]["role_id"] == created_role.id
+    assert reactions == ["✅"]
+    assert edited_messages

--- a/tests/unit/test_role_toggle_service.py
+++ b/tests/unit/test_role_toggle_service.py
@@ -1,0 +1,84 @@
+from byte_bot.services.database_service import DatabaseService
+from byte_bot.services.role_toggle_service import RoleToggleService
+
+
+def test_role_toggle_service_upserts_and_reads_panel(database_path):
+    service = RoleToggleService(DatabaseService(database_path))
+
+    panel = service.upsert_panel(
+        guild_id=123,
+        message_id=456,
+        role_id=789,
+        role_name="ByteClubHQ",
+        emoji="✅",
+        title="ByteClubHQ Access",
+    )
+
+    assert panel.guild_id == 123
+    assert panel.message_id == 456
+    assert panel.role_id == 789
+    assert panel.role_name == "ByteClubHQ"
+    assert panel.emoji == "✅"
+    assert panel.title == "ByteClubHQ Access"
+    assert service.get_panel(123, role_name="ByteClubHQ") == panel
+
+
+def test_role_toggle_service_updates_panel_without_losing_ids(database_path):
+    service = RoleToggleService(DatabaseService(database_path))
+    service.upsert_panel(
+        guild_id=123,
+        message_id=456,
+        role_id=789,
+        role_name="ByteClubHQ",
+        emoji="✅",
+        title="ByteClubHQ Access",
+    )
+
+    updated_panel = service.upsert_panel(
+        guild_id=123,
+        role_name="ByteClubHQ",
+        emoji="🔥",
+        title="Updated Access",
+    )
+
+    assert updated_panel.message_id == 456
+    assert updated_panel.role_id == 789
+    assert updated_panel.emoji == "🔥"
+    assert updated_panel.title == "Updated Access"
+
+
+def test_role_toggle_service_finds_custom_emoji_panel(database_path):
+    service = RoleToggleService(DatabaseService(database_path))
+    custom_emoji = "<:byteclub:123456789012345678>"
+    service.upsert_panel(
+        guild_id=123,
+        message_id=456,
+        role_id=789,
+        role_name="ByteClubHQ",
+        emoji=custom_emoji,
+        title="ByteClubHQ Access",
+    )
+
+    panel = service.find_matching_panel(guild_id=123, message_id=456, emoji=custom_emoji)
+
+    assert panel is not None
+    assert panel.emoji == custom_emoji
+
+
+def test_role_toggle_service_lists_panels_by_role_name(database_path):
+    service = RoleToggleService(DatabaseService(database_path))
+    service.upsert_panel(guild_id=123, role_name="Z Role", emoji="✅", title="Z Access")
+    service.upsert_panel(guild_id=123, role_name="A Role", emoji="🔥", title="A Access")
+
+    panels = service.list_panels(123)
+
+    assert [panel.role_name for panel in panels] == ["A Role", "Z Role"]
+
+
+def test_role_toggle_service_deletes_panel(database_path):
+    service = RoleToggleService(DatabaseService(database_path))
+    service.upsert_panel(guild_id=123, role_name="ByteClubHQ", emoji="✅", title="ByteClubHQ Access")
+
+    service.delete_panel(guild_id=123, role_name="ByteClubHQ")
+
+    assert service.get_panel(123, role_name="ByteClubHQ") is None


### PR DESCRIPTION
## Description

This PR adds a DB-backed, reaction-based role toggle flow for the `ByteClubHQ` role (and any additional roles you configure).

Changes included in this PR:
- moved the role-toggle logic into a dedicated cog: `byte_bot/cogs/role_toggle.py`
- added a small service layer for DB access: `byte_bot/services/role_toggle_service.py`
- stored panel state in SQLite (no JSON files):
  - `role_toggle_panels(guild_id, role_name, message_id, emoji, title)`
- uses a single channel configured via env (`ROLE_CHANNEL_ID`) for all panels
- automatically creates the default `ByteClubHQ` panel/role if missing on startup
- added admin commands to manage panels:
  - `/roletoggle_add` (create/update a panel by `role_name`)
  - `/roletoggle_delete` (deletes the panel message + DB config; optional flag to delete the Discord role)
  - `/roletoggle_list` and `/roletoggle_status`
- reaction add/remove handling is now done via cog listeners (no raw reaction wiring in `ByteBot`)
- updated `docker-compose.yml` to persist `./database` (so sqlite state survives restarts)
- updated `example.env` to document `ROLE_CHANNEL_ID` / `DATABASE_PATH`

## Linked Issue

No Linked Issue Yet

## Testing Instructions

1. Set env vars:
   - `DISCORD_TOKEN`
   - `ROLE_CHANNEL_ID` (the text channel where panels should be posted)
   - `DATABASE_PATH` (optional; defaults to `./database/byte_bot.db`)
2. Ensure the bot has permissions to:
   - manage roles
   - read/send messages in the target channel
   - add reactions
3. Start the bot and confirm it creates the `ByteClubHQ` role if it does not already exist.
4. Confirm the bot sends/updates a role-toggle embed in the configured channel with a `✅` reaction.
5. React to the message with `✅` and verify the user receives the `ByteClubHQ` role.
6. Remove the `✅` reaction and verify the role is removed.
7. Restart the bot and verify it reuses/edits the existing role-toggle message instead of posting a duplicate one.
8. (Optional) Run:
   - `/roletoggle_add role_name:"SomeOtherRole"`
   - verify the new panel appears and toggles that role too
9. (Optional) Run:
   - `/roletoggle_delete role_name:"SomeOtherRole"`
   - verify the panel message is deleted and reactions no longer affect the role

## Checklist

- [x] PR has a meaningful title and description. **NOT**: `Merge branch into main`
- [ ] I have linked the relevant issue(s) that this PR addresses.
- [x] I have fully tested all features present in this PR
- [x] I have updated any relevant documentation (if applicable).
- [x] This PR fully addresses the linked issue(s). If not, I have explained why in the PR description

