### PR TITLE
task: migrate business logic from cogs to services

### DIFF
--- a/byte_bot/cogs/feature_suggest.py
+++ b/byte_bot/cogs/feature_suggest.py
@@ -5,6 +5,7 @@ from discord.ext import commands
 from discord import app_commands
 
 from byte_bot.byte_bot import ByteBot
+from byte_bot.services.feature_suggest_service import create_feature_suggestion
 
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
@@ -91,12 +92,11 @@ class FeatureSuggest(commands.Cog):
             discord.DiscordException: If sending the embed or creating the thread
                 fails due to permissions or other Discord API issues.
         """
-        if len(title) > 256:
-            await self._reply(ctx, "The title cannot exceed 256 characters.")
+        try:
+            suggestion = create_feature_suggestion(title, summary)
+        except ValueError as error:
+            await self._reply(ctx, str(error))
             return
-        if len(summary) > 1024:
-            await self._reply(ctx, "The summary cannot exceed 1024 characters.")
-            return 
 
         channel = self.bot.get_channel(self.feature_forum_channel_id)
         if channel is None:
@@ -112,15 +112,15 @@ class FeatureSuggest(commands.Cog):
             description="Allow community members to submit a feature request/suggestion.",
             color=discord.Color.brand_red(),
         )
-        embed.add_field(name="Title", value=f"{title}", inline=False)
-        embed.add_field(name="Summary", value=f"{summary}", inline=False)
+        embed.add_field(name="Title", value=f"{suggestion.title}", inline=False)
+        embed.add_field(name="Summary", value=f"{suggestion.summary}", inline=False)
         embed.set_footer(text=f"Requested by {ctx.author.display_name}", icon_url=icon_url)
 
         # --- Send embed to forum thread ---
         try:
             if isinstance(channel, discord.ForumChannel):
                 thread_with_message = await channel.create_thread(
-                    name=title,
+                    name=suggestion.title,
                     embed=embed
                 )
                 thread = thread_with_message.thread

--- a/byte_bot/cogs/interviewprompt.py
+++ b/byte_bot/cogs/interviewprompt.py
@@ -1,14 +1,9 @@
 import discord
 from discord.ext import commands
-import random
 from dataclasses import dataclass
-import json
 
 from byte_bot.cogs.utilities import logger
-
-# Loads the question:answer from the json file
-with open("byte_bot/data/interview_questions.json") as f:
-    questions = json.load(f)
+from byte_bot.services.interviewprompt_service import get_random_question, QUESTIONS
 
 # Embed helper
 def build_question_embed(q, title="Ready for an interview?"):
@@ -38,10 +33,10 @@ class InterviewView(discord.ui.View):
 
     @discord.ui.button(label="Another Question", style=discord.ButtonStyle.primary)
     async def another_question(self, interaction: discord.Interaction, button: discord.ui.Button):
-        q = random.choice(questions)
+        q = get_random_question()
         # Avoids sending the same question in a row
         while q == self.previous_question:
-            q = random.choice(questions)
+            q = get_random_question()
         self.previous_question = q
 
         embed = build_question_embed(q, title="More questions!")
@@ -67,10 +62,10 @@ class InterviewPrompt(commands.Cog):
             Returns:
                 None: Sends an ephemeral embed directly to the user.
         """
-        q = random.choice(questions)
+        q = get_random_question()
         embed = build_question_embed(q)
 
-        view = InterviewView(questions)
+        view = InterviewView(QUESTIONS)
 
         view.add_item(
             discord.ui.Button(

--- a/byte_bot/cogs/leetcode.py
+++ b/byte_bot/cogs/leetcode.py
@@ -1,33 +1,9 @@
 import discord
 from discord.ext import commands
-import requests
-import re
-import random
-from dataclasses import dataclass
-from typing import Literal
-from typing import List
 
-
-@dataclass
-class SubmissionStat:
-    difficulty: str | None
-    count: int | None
-
-@dataclass
-class Profile:
-    real_name: str | None
-    ranking: int | None
-    reputation: int | None
-    country: str | None
-
-@dataclass
-class LeetCodeUser:
-    username: str | None
-    profile: Profile | None
-    submissions: List[SubmissionStat] | None
+from byte_bot.services.leetcode_service import get_leetcode_profile, get_leetcode_daily, get_leetcode_random
 
 class LeetCode(commands.Cog):
-    url = "https://leetcode.com/graphql"
     def __init__(self, bot):
         self.bot = bot
 
@@ -36,71 +12,17 @@ class LeetCode(commands.Cog):
         print("Bytebot is online")
 
     @commands.hybrid_command()
-    async def leetcode_profile(self, ctx, profile: str = None):
+    async def leetcode_profile(self, ctx, profile: str | None = None):
 
         if profile is None:
             await ctx.send("You must provide a leetcode username.\nUsage: `/leetcodeprofile <username>`\n", ephemeral=True)
             return
 
-        # This is where the graphql query happens, we can also query for problems, found this documentation https://jacoblincool.github.io/LeetCode-Query/
-        query = """
-        query getUserProfile($username: String!) {
-        matchedUser(username: $username) {
-            username
-            profile {
-            realName
-            ranking
-            reputation
-            countryName
-            }
-            submitStats: submitStatsGlobal {
-            acSubmissionNum {
-                difficulty
-                count
-            }
-            }
-        }
-        }
-        """
-        variables = {
-            "username": f"{profile}"
-        }
-        response = requests.post(
-            self.url,
-            json={"query": query, "variables": variables}
-        )
-
-        data = response.json()
-
-        # First check if that users profile exists
-        if not (user_data := data.get("data").get("matchedUser")):
-            await ctx.send("Failed to find a leetcode user with that username", ephemeral=True)
+        try:
+            user = get_leetcode_profile(profile)
+        except ValueError as err:
+            await ctx.send(err, ephemeral=True)
             return
-
-        # Parse the data
-        profile_data = user_data.get("profile")
-        submission_data = user_data.get("submitStats").get("acSubmissionNum")
-
-        profile = Profile(
-            real_name=profile_data.get("realName"),
-            ranking=profile_data.get("ranking"),
-            reputation=profile_data.get("reputation"),
-            country=profile_data.get("countryName"),
-        )
-
-        submissions = [
-            SubmissionStat(
-                difficulty=stat.get("difficulty"),
-                count=stat.get("count")
-            )
-            for stat in submission_data
-        ]
-
-        user = LeetCodeUser(
-            username=user_data.get("username"),
-            profile=profile,
-            submissions=submissions
-        )
         
         # Create a discord Embed object to display
         embed = discord.Embed()
@@ -110,41 +32,18 @@ class LeetCode(commands.Cog):
         embed.add_field(name="Reputation", value=user.profile.reputation, inline=True)
         embed.add_field(name="Submissions", value="Total Problems solved 🎉", inline=False)
 
-        for stat in submissions:
+        for stat in user.submissions:
             embed.add_field(name=f"{stat.difficulty}", value=f"{stat.count}", inline=True)
 
         await ctx.send(embed=embed, ephemeral=True)
 
     @commands.hybrid_command()
     async def leetcode_daily(self, ctx):
-        query = """
-                query questionOfToday {
-                activeDailyCodingChallengeQuestion {
-                    date
-                    link
-                    question {
-                    title
-                    titleSlug
-                    difficulty
-                    acRate
-                    questionFrontendId
-                    }
-                }
-                }
-                """
 
-        variables = {
-        }
-        response = requests.post(
-            self.url,
-            json={"query": query, "variables": variables}
-        )
-
-        data = response.json()
-
-        # Parse the daily challenge json
-        if not (problem_data := data.get("data", {}).get("activeDailyCodingChallengeQuestion")):
-            await ctx.send("Failed to find a daily leetcode problem", ephemeral=True)
+        try:
+            problem_data = get_leetcode_daily()
+        except ValueError as err:
+            await ctx.send(err, ephemeral=True)
             return
 
         embed = discord.Embed()
@@ -153,37 +52,20 @@ class LeetCode(commands.Cog):
         embed.add_field(name="Link", value="https://leetcode.com" + (problem_data.get("link")), inline=False)
         await ctx.send(embed=embed, ephemeral=True)
 
-
     @commands.hybrid_command()
-    async def leetcode_random(self, ctx, difficulty: Literal["Easy", "Medium", "Hard"] | None = None):
-        # Because filtering is no longer supported in the graphql endpoint I am querying the rest endpoint for all problems
-        url = "https://leetcode.com/api/problems/all/"
-
-        difficulties: dict[str, int] = {"Easy": 1, "Medium": 2, "Hard": 3}
-
-        if difficulty not in difficulties:
-            await ctx.send("You must provide a difficulty.\nUsage: `/leetcoderandom <difficulty>`\n", ephemeral=True)
-            return
-
-        response = requests.get(url)
-        data = response.json()
-        questions = data.get("stat_status_pairs")  # list of all problems
-
-        # Filter by difficulty
-        filtered = [
-            q for q in questions
-            if q.get("difficulty", {}).get("level") == difficulties.get(difficulty)
-        ]
+    async def leetcode_random(self, ctx, difficulty = None):
         
-        random_problem = random.choice(filtered)
+        try:
+            random_problem = get_leetcode_random(difficulty)
+        except ValueError as err:
+            await ctx.send(err, ephemeral=True)
+            return
 
         embed = discord.Embed()
         embed.add_field(name="Title", value=random_problem.get("stat", {}).get("question__title"), inline=False)
         embed.add_field(name="Difficulty", value=f"{difficulty}", inline=False)
         embed.add_field(name="Link", value="https://leetcode.com/problems/" + (random_problem.get("stat", {}).get("question__title_slug")), inline=False)
         await ctx.send(embed=embed, ephemeral=True)
-
-
 
 async def setup(bot):
     await bot.add_cog(LeetCode(bot))

--- a/byte_bot/cogs/leetcode.py
+++ b/byte_bot/cogs/leetcode.py
@@ -21,7 +21,7 @@ class LeetCode(commands.Cog):
         try:
             user = get_leetcode_profile(profile)
         except ValueError as err:
-            await ctx.send(err, ephemeral=True)
+            await ctx.send(str(err), ephemeral=True)
             return
         
         # Create a discord Embed object to display
@@ -43,7 +43,7 @@ class LeetCode(commands.Cog):
         try:
             problem_data = get_leetcode_daily()
         except ValueError as err:
-            await ctx.send(err, ephemeral=True)
+            await ctx.send(str(err), ephemeral=True)
             return
 
         embed = discord.Embed()
@@ -58,7 +58,7 @@ class LeetCode(commands.Cog):
         try:
             random_problem = get_leetcode_random(difficulty)
         except ValueError as err:
-            await ctx.send(err, ephemeral=True)
+            await ctx.send(str(err), ephemeral=True)
             return
 
         embed = discord.Embed()

--- a/byte_bot/services/feature_suggest_service.py
+++ b/byte_bot/services/feature_suggest_service.py
@@ -6,11 +6,12 @@ class FeatureSuggestion:
     title: str
     summary: str
 
+    def __post_init__(self):
+        if len(self.title) > 256:
+            raise ValueError("The title cannot exceed 256 characters.")
+        if len(self.summary) > 1024:
+            raise ValueError("The summary cannot exceed 1024 characters.")
+
 
 def create_feature_suggestion(title: str, summary: str) -> FeatureSuggestion:
-    if len(title) > 256:
-        raise ValueError("The title cannot exceed 256 characters.")
-    if len(summary) > 1024:
-        raise ValueError("The summary cannot exceed 1024 characters.")
-
     return FeatureSuggestion(title=title, summary=summary)

--- a/byte_bot/services/feature_suggest_service.py
+++ b/byte_bot/services/feature_suggest_service.py
@@ -1,0 +1,16 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class FeatureSuggestion:
+    title: str
+    summary: str
+
+
+def create_feature_suggestion(title: str, summary: str) -> FeatureSuggestion:
+    if len(title) > 256:
+        raise ValueError("The title cannot exceed 256 characters.")
+    if len(summary) > 1024:
+        raise ValueError("The summary cannot exceed 1024 characters.")
+
+    return FeatureSuggestion(title=title, summary=summary)

--- a/byte_bot/services/interviewprompt_service.py
+++ b/byte_bot/services/interviewprompt_service.py
@@ -1,0 +1,9 @@
+import json
+import random
+
+# Loads the question:answer from the json file
+with open("byte_bot/data/interview_questions.json") as f:
+    QUESTIONS = json.load(f)
+
+def get_random_question():
+    return random.choice(QUESTIONS)

--- a/byte_bot/services/leetcode_service.py
+++ b/byte_bot/services/leetcode_service.py
@@ -1,0 +1,138 @@
+import requests
+from dataclasses import dataclass
+from typing import List
+import random
+
+@dataclass
+class SubmissionStat:
+    difficulty: str | None
+    count: int | None
+
+@dataclass
+class Profile:
+    real_name: str | None
+    ranking: int | None
+    reputation: int | None
+    country: str | None
+
+@dataclass
+class LeetCodeUser:
+    username: str | None
+    profile: Profile | None
+    submissions: List[SubmissionStat] | None
+
+LEETCODE_GRAPHQL_URL = "https://leetcode.com/graphql"
+LEETCODE_PROBLEMS_URL = "https://leetcode.com/api/problems/all/"
+
+def get_leetcode_profile(profile: str):
+
+    # This is where the graphql query happens, we can also query for problems, found this documentation https://jacoblincool.github.io/LeetCode-Query/
+    query = """
+                query getUserProfile($username: String!) {
+                matchedUser(username: $username) {
+                    username
+                    profile {
+                    realName
+                    ranking
+                    reputation
+                    countryName
+                    }
+                    submitStats: submitStatsGlobal {
+                    acSubmissionNum {
+                        difficulty
+                        count
+                    }
+                    }
+                }
+                }
+                """
+        
+    variables = {
+        "username": f"{profile}"
+    }
+    response = requests.post(
+        LEETCODE_GRAPHQL_URL,
+        json={"query": query, "variables": variables}
+    )
+
+    data = response.json()
+
+    # First check if that users profile exists
+    if not (user_data := data.get("data").get("matchedUser")):
+            raise ValueError("Failed to find a leetcode user with that username")
+    
+    # Parse the data
+    profile_data = user_data.get("profile")
+    submission_data = user_data.get("submitStats").get("acSubmissionNum")
+
+    profile = Profile(
+        real_name=profile_data.get("realName"),
+        ranking=profile_data.get("ranking"),
+        reputation=profile_data.get("reputation"),
+        country=profile_data.get("countryName"),
+    )
+
+    submissions = [
+        SubmissionStat(
+            difficulty=stat.get("difficulty"),
+            count=stat.get("count")
+        )
+        for stat in submission_data
+    ]
+
+    user = LeetCodeUser(
+        username=user_data.get("username"),
+        profile=profile,
+        submissions=submissions
+    )
+
+    return user
+
+def get_leetcode_daily():
+    query = """
+        query questionOfToday {
+        activeDailyCodingChallengeQuestion {
+            date
+            link
+            question {
+            title
+            titleSlug
+            difficulty
+            acRate
+            questionFrontendId
+            }
+        }
+        }
+        """
+
+    variables = {
+    }
+    response = requests.post(
+        LEETCODE_GRAPHQL_URL,
+        json={"query": query, "variables": variables}
+    )
+
+    data = response.json()
+
+    if not (problem_data := data.get("data", {}).get("activeDailyCodingChallengeQuestion")):
+        raise ValueError("Failed to find a daily leetcode problem")
+    
+    return problem_data
+
+def get_leetcode_random(difficulty):
+    difficulties: dict[str, int] = {"easy": 1, "medium": 2, "hard": 3}
+
+    if difficulty is None or difficulty.lower() not in difficulties:
+        raise ValueError("You must provide a difficulty: `Easy`, `Medium`, `Hard`\nUsage: `/leetcoderandom <difficulty>`\n")
+    
+    response = requests.get(LEETCODE_PROBLEMS_URL)
+    data = response.json()
+    questions = data.get("stat_status_pairs")  # list of all problems
+
+    # Filter by difficulty
+    filtered = [
+        q for q in questions
+        if q.get("difficulty", {}).get("level") == difficulties.get(difficulty.lower())
+    ]
+    
+    return random.choice(filtered)

--- a/byte_bot/services/leetcode_service.py
+++ b/byte_bot/services/leetcode_service.py
@@ -58,7 +58,7 @@ def get_leetcode_profile(profile: str):
     data = response.json()
 
     # First check if that users profile exists
-    if not (user_data := data.get("data").get("matchedUser")):
+    if not (user_data := data.get("data", {}).get("matchedUser")):
         raise ValueError("Failed to find a leetcode user with that username")
     
     # Parse the data

--- a/byte_bot/services/leetcode_service.py
+++ b/byte_bot/services/leetcode_service.py
@@ -28,24 +28,24 @@ def get_leetcode_profile(profile: str):
 
     # This is where the graphql query happens, we can also query for problems, found this documentation https://jacoblincool.github.io/LeetCode-Query/
     query = """
-                query getUserProfile($username: String!) {
-                matchedUser(username: $username) {
-                    username
-                    profile {
-                    realName
-                    ranking
-                    reputation
-                    countryName
-                    }
-                    submitStats: submitStatsGlobal {
-                    acSubmissionNum {
-                        difficulty
-                        count
-                    }
-                    }
-                }
-                }
-                """
+        query getUserProfile($username: String!) {
+        matchedUser(username: $username) {
+            username
+            profile {
+            realName
+            ranking
+            reputation
+            countryName
+            }
+            submitStats: submitStatsGlobal {
+            acSubmissionNum {
+                difficulty
+                count
+            }
+            }
+        }
+        }
+    """
         
     variables = {
         "username": f"{profile}"
@@ -59,7 +59,7 @@ def get_leetcode_profile(profile: str):
 
     # First check if that users profile exists
     if not (user_data := data.get("data").get("matchedUser")):
-            raise ValueError("Failed to find a leetcode user with that username")
+        raise ValueError("Failed to find a leetcode user with that username")
     
     # Parse the data
     profile_data = user_data.get("profile")

--- a/example.env
+++ b/example.env
@@ -1,3 +1,4 @@
 # Copy this file to a new file named .env and fill in the values for your personal environment variables.
 # You can run cp example.env .env on the command line or just create the new file in your IDE
 DISCORD_TOKEN=
+FEATURE_FORUM_CHANNEL_ID=

--- a/tests/integration/test_interviewprompt.py
+++ b/tests/integration/test_interviewprompt.py
@@ -1,0 +1,82 @@
+import pytest
+import discord.ext.test as dpytest
+
+
+def _patch_interviewprompt_services(monkeypatch, bot, replacement):
+    command = bot.get_command("interviewprompt")
+    monkeypatch.setitem(command.callback.__globals__, "get_random_question", replacement)
+    monkeypatch.setitem(
+        command.callback.__globals__,
+        "QUESTIONS",
+        [
+            {
+                "question": "What is Python?",
+                "answer": "A programming language.",
+            }
+        ],
+    )
+
+
+@pytest.mark.asyncio
+async def test_interviewprompt_sends_embed(bot, monkeypatch):
+    _patch_interviewprompt_services(
+        monkeypatch,
+        bot,
+        lambda: {
+            "question": "What is Python?",
+            "answer": "A programming language.",
+        },
+    )
+
+    await dpytest.message("+interviewprompt")
+    msg = dpytest.get_message()
+
+    assert len(msg.embeds) == 1
+    assert msg.embeds[0].title == "Ready for an interview?"
+
+
+@pytest.mark.asyncio
+async def test_interviewprompt_embed_contains_question_and_hidden_answer(bot, monkeypatch):
+    _patch_interviewprompt_services(
+        monkeypatch,
+        bot,
+        lambda: {
+            "question": "Explain list comprehensions.",
+            "answer": "A compact syntax for building lists.",
+        },
+    )
+
+    await dpytest.message("+interviewprompt")
+    msg = dpytest.get_message()
+    field_map = {field.name: field.value for field in msg.embeds[0].fields}
+
+    assert field_map["Question:"] == "Explain list comprehensions."
+    assert field_map["Answer"] == "||A compact syntax for building lists.||"
+
+
+@pytest.mark.asyncio
+async def test_interviewprompt_adds_quiz_source_button_to_view(bot, monkeypatch):
+    added_items = []
+
+    _patch_interviewprompt_services(
+        monkeypatch,
+        bot,
+        lambda: {
+            "question": "What is Python?",
+            "answer": "A programming language.",
+        },
+    )
+    command = bot.get_command("interviewprompt")
+    interview_view_class = command.callback.__globals__["InterviewView"]
+    original_add_item = interview_view_class.add_item
+
+    def spy_add_item(self, item):
+        added_items.append(item)
+        return original_add_item(self, item)
+
+    monkeypatch.setattr(interview_view_class, "add_item", spy_add_item)
+
+    await dpytest.message("+interviewprompt")
+
+    assert len(added_items) == 1
+    assert added_items[0].label == "Quiz Source"

--- a/tests/integration/test_leetcode.py
+++ b/tests/integration/test_leetcode.py
@@ -1,96 +1,101 @@
 import pytest
 import discord.ext.test as dpytest
 
-import byte_bot.cogs.leetcode as leetcode_module
+from byte_bot.services.leetcode_service import LeetCodeUser, Profile, SubmissionStat
 
-class MockResponse:
-    def __init__(self, payload):
-        self._payload = payload
 
-    def json(self):
-        return self._payload
+def patch_command_service(monkeypatch, command, service_name, replacement):
+    monkeypatch.setitem(command.callback.__globals__, service_name, replacement)
 
-def fake_post_user(url, json):
-    username = json["variables"]["username"]
-
-    if username == "niits":
-        return MockResponse(
-            {
-                "data": {
-                    "matchedUser": {
-                        "username": "niits",
-                        "profile": {
-                            "realName": "Niits Test",
-                            "ranking": 12345,
-                            "reputation": 10,
-                            "countryName": "Morocco",
-                        },
-                        "submitStats": {
-                            "acSubmissionNum": [
-                                {"difficulty": "All", "count": 100},
-                                {"difficulty": "Easy", "count": 50},
-                                {"difficulty": "Medium", "count": 40},
-                                {"difficulty": "Hard", "count": 10},
-                            ]
-                        },
-                    }
-                }
-            }
-        )
-
-    return MockResponse({"data": {"matchedUser": None}})
-
-def fake_post_random(url, json):
-    return MockResponse(
-        {
-            "data": {
-                "activeDailyCodingChallengeQuestion":{
-                    "date":"1111-11-11",
-                    "link":"linkToProblem",
-                    "question":{
-                        "title":"testTitle",
-                        "titleSlug":"testTitleSlug",
-                        "difficulty":"Easy",
-                        "acRate":1234,
-                        "questionFrontendId":"1234"
-                    }
-                }
-            }
-        }
-    )
 
 @pytest.mark.asyncio
 async def test_leetcode_no_username(bot):
     await dpytest.message("+leetcode_profile")
     assert dpytest.verify().message().contains().content("You must provide a leetcode username")
 
+
 @pytest.mark.asyncio
 async def test_leetcode_username(bot, monkeypatch):
-    monkeypatch.setattr(leetcode_module.requests, "post", fake_post_user)
+    patch_command_service(
+        monkeypatch,
+        bot.get_command("leetcode_profile"),
+        "get_leetcode_profile",
+        lambda profile: LeetCodeUser(
+            username="niits",
+            profile=Profile(
+                real_name="Niits Test",
+                ranking=12345,
+                reputation=10,
+                country="Morocco",
+            ),
+            submissions=[
+                SubmissionStat(difficulty="Easy", count=50),
+                SubmissionStat(difficulty="Medium", count=40),
+            ],
+        ),
+    )
+
     await dpytest.message("+leetcode_profile niits")
     resp = dpytest.get_message()
     assert len(resp.embeds) == 1
 
+
 @pytest.mark.asyncio
 async def test_leetcode_unknown_username(bot, monkeypatch):
-    monkeypatch.setattr(leetcode_module.requests, "post", fake_post_user)
+    def raise_value_error(profile):
+        raise ValueError("Failed to find a leetcode user with that username")
+
+    patch_command_service(
+        monkeypatch,
+        bot.get_command("leetcode_profile"),
+        "get_leetcode_profile",
+        raise_value_error,
+    )
+
     await dpytest.message("+leetcode_profile unknownuser")
     assert dpytest.verify().message().contains().content("Failed to find a leetcode user with that username")
 
+
 @pytest.mark.asyncio
 async def test_leetcode_daily(bot, monkeypatch):
+    patch_command_service(
+        monkeypatch,
+        bot.get_command("leetcode_daily"),
+        "get_leetcode_daily",
+        lambda: {
+            "link": "/problems/test-title",
+            "question": {
+                "title": "testTitle",
+                "difficulty": "Easy",
+            },
+        },
+    )
+
     await dpytest.message("+leetcode_daily")
     resp = dpytest.get_message()
     assert len(resp.embeds) == 1
 
+
 @pytest.mark.asyncio
 async def test_leetcode_random(bot, monkeypatch):
-    monkeypatch.setattr(leetcode_module.requests, "post", fake_post_random)
+    patch_command_service(
+        monkeypatch,
+        bot.get_command("leetcode_random"),
+        "get_leetcode_random",
+        lambda difficulty: {
+            "stat": {
+                "question__title": "Two Sum",
+                "question__title_slug": "two-sum",
+            }
+        },
+    )
+
     await dpytest.message("+leetcode_random Easy")
     resp = dpytest.get_message()
     assert len(resp.embeds) == 1
 
+
 @pytest.mark.asyncio
 async def test_leetcode_random_no_input(bot, monkeypatch):
     await dpytest.message("+leetcode_random")
-    assert dpytest.verify().message().contains().content("You must provide a difficulty.")
+    assert dpytest.verify().message().contains().content("You must provide a difficulty")

--- a/tests/integration/test_suggest_feature.py
+++ b/tests/integration/test_suggest_feature.py
@@ -5,8 +5,10 @@ import discord
 from discord.ext import commands
 import discord.ext.test as dpytest
 
+from byte_bot.services.feature_suggest_service import FeatureSuggestion
+
+
 def _make_forum_channel():
-    """Return a ForumChannel mock with a working create_thread"""
     mock_thread = MagicMock(spec=discord.Thread)
     mock_thread.name = "Test Feature"
 
@@ -17,69 +19,86 @@ def _make_forum_channel():
     mock_channel.create_thread = AsyncMock(return_value=mock_thread_with_message)
     return mock_channel
 
+
 def _block_dms(monkeypatch):
-    """
-    Force Member.send() to raise Forbidden so _reply() falls back to ctx.send().
-    dpytest does not queue DMs, so this is required to capture text command replies.
-    """
     async def _raise_forbidden(*args, **kwargs):
         raise discord.Forbidden(MagicMock(), "Cannot send messages to this user")
 
     monkeypatch.setattr(discord.Member, "send", _raise_forbidden)
+
+
+def _patch_feature_service(monkeypatch, bot, replacement):
+    command = bot.get_command("suggestfeature")
+    monkeypatch.setitem(command.callback.__globals__, "create_feature_suggestion", replacement)
+
 
 @pytest.mark.asyncio
 async def test_suggestfeature_created_thread(bot, monkeypatch):
     _block_dms(monkeypatch)
     mock_channel = _make_forum_channel()
     monkeypatch.setattr(bot, "get_channel", lambda _: mock_channel)
+    _patch_feature_service(
+        monkeypatch,
+        bot,
+        lambda title, summary: FeatureSuggestion(title=title, summary=summary),
+    )
 
     await dpytest.message('+suggestfeature "Dark Mode" Add a dark theme for users.')
-    
+
     embed = mock_channel.create_thread.call_args[1]["embed"]
     field_map = {f.name: f.value for f in embed.fields}
+    assert mock_channel.create_thread.call_args[1]["name"] == "Dark Mode"
     assert field_map.get("Title") == "Dark Mode"
     assert field_map.get("Summary") == "Add a dark theme for users."
+
 
 @pytest.mark.asyncio
 async def test_suggestfeature_sends_confirmation(bot, monkeypatch):
     _block_dms(monkeypatch)
     monkeypatch.setattr(bot, "get_channel", lambda _: _make_forum_channel())
+    _patch_feature_service(
+        monkeypatch,
+        bot,
+        lambda title, summary: FeatureSuggestion(title=title, summary=summary),
+    )
 
     await dpytest.message('+suggestfeature "Dark Mode" Add a dark theme for users.')
 
-    assert dpytest.verify().message().contains().content("✅")
+    assert dpytest.verify().message().contains().content("submitted")
+
 
 @pytest.mark.asyncio
 async def test_suggestfeature_single_word_title(bot, monkeypatch):
     _block_dms(monkeypatch)
     mock_channel = _make_forum_channel()
     monkeypatch.setattr(bot, "get_channel", lambda _: mock_channel)
+    _patch_feature_service(
+        monkeypatch,
+        bot,
+        lambda title, summary: FeatureSuggestion(title=title, summary=summary),
+    )
 
     await dpytest.message("+suggestfeature Notifications Add push notifications.")
 
     assert mock_channel.create_thread.call_args[1]["name"] == "Notifications"
 
+
 @pytest.mark.asyncio
-async def test_suggestfeature_title_too_long(bot, monkeypatch):
+async def test_suggestfeature_service_error_is_reported(bot, monkeypatch):
     _block_dms(monkeypatch)
     mock_channel = _make_forum_channel()
     monkeypatch.setattr(bot, "get_channel", lambda _: mock_channel)
 
-    await dpytest.message(f'+suggestfeature "{"A" * 257}" Some summary.')
+    def raise_value_error(title, summary):
+        raise ValueError("The title cannot exceed 256 characters.")
+
+    _patch_feature_service(monkeypatch, bot, raise_value_error)
+
+    await dpytest.message('+suggestfeature "Dark Mode" Add a dark theme for users.')
 
     mock_channel.create_thread.assert_not_called()
     assert dpytest.verify().message().contains().content("256")
 
-@pytest.mark.asyncio
-async def test_suggestfeature_summary_too_long(bot, monkeypatch):
-    _block_dms(monkeypatch)
-    mock_channel = _make_forum_channel()
-    monkeypatch.setattr(bot, "get_channel", lambda _: mock_channel)
-
-    await dpytest.message(f'+suggestfeature "Title" {"B" * 1025}')
-
-    mock_channel.create_thread.assert_not_called()
-    assert dpytest.verify().message().contains().content("1024")
 
 @pytest.mark.asyncio
 async def test_suggestfeature_no_args(bot, monkeypatch):
@@ -90,6 +109,7 @@ async def test_suggestfeature_no_args(bot, monkeypatch):
 
     assert dpytest.verify().message().contains().content("+suggestfeature")
 
+
 @pytest.mark.asyncio
 async def test_suggestfeature_missing_summary(bot, monkeypatch):
     _block_dms(monkeypatch)
@@ -99,23 +119,36 @@ async def test_suggestfeature_missing_summary(bot, monkeypatch):
 
     assert dpytest.verify().message().contains().content("/suggestfeature")
 
+
 @pytest.mark.asyncio
 async def test_suggestfeature_channel_not_found(bot, monkeypatch):
     _block_dms(monkeypatch)
     monkeypatch.setattr(bot, "get_channel", lambda _: None)
+    _patch_feature_service(
+        monkeypatch,
+        bot,
+        lambda title, summary: FeatureSuggestion(title=title, summary=summary),
+    )
 
     await dpytest.message('+suggestfeature "Dark Mode" Some summary.')
 
-    assert dpytest.verify().message().contains().content("❌")
+    assert dpytest.verify().message().contains().content("Could not find the forum channel")
+
 
 @pytest.mark.asyncio
 async def test_suggestfeature_wrong_channel_type(bot, monkeypatch):
     _block_dms(monkeypatch)
     monkeypatch.setattr(bot, "get_channel", lambda _: MagicMock(spec=discord.TextChannel))
+    _patch_feature_service(
+        monkeypatch,
+        bot,
+        lambda title, summary: FeatureSuggestion(title=title, summary=summary),
+    )
 
     await dpytest.message('+suggestfeature "Dark Mode" Some summary.')
 
     assert dpytest.verify().message().contains().content("misconfigured")
+
 
 @pytest.mark.asyncio
 async def test_suggestfeature_wrong_channel_type_no_thread_created(bot, monkeypatch):
@@ -123,10 +156,16 @@ async def test_suggestfeature_wrong_channel_type_no_thread_created(bot, monkeypa
     mock_text_channel = MagicMock(spec=discord.TextChannel)
     mock_text_channel.create_thread = AsyncMock()
     monkeypatch.setattr(bot, "get_channel", lambda _: mock_text_channel)
+    _patch_feature_service(
+        monkeypatch,
+        bot,
+        lambda title, summary: FeatureSuggestion(title=title, summary=summary),
+    )
 
     await dpytest.message('+suggestfeature "Dark Mode" Some summary.')
 
     mock_text_channel.create_thread.assert_not_called()
+
 
 @pytest.mark.asyncio
 async def test_suggestfeature_discord_exception(bot, monkeypatch):
@@ -134,7 +173,12 @@ async def test_suggestfeature_discord_exception(bot, monkeypatch):
     mock_channel = MagicMock(spec=discord.ForumChannel)
     mock_channel.create_thread = AsyncMock(side_effect=discord.DiscordException("API error"))
     monkeypatch.setattr(bot, "get_channel", lambda _: mock_channel)
+    _patch_feature_service(
+        monkeypatch,
+        bot,
+        lambda title, summary: FeatureSuggestion(title=title, summary=summary),
+    )
 
     await dpytest.message('+suggestfeature "Dark Mode" Some summary.')
 
-    assert dpytest.verify().message().contains().content("❌")
+    assert dpytest.verify().message().contains().content("Failed to submit your feature suggestion")

--- a/tests/unit/test_feature_suggest_service.py
+++ b/tests/unit/test_feature_suggest_service.py
@@ -1,0 +1,32 @@
+import pytest
+
+from byte_bot.services.feature_suggest_service import create_feature_suggestion
+
+
+def test_create_feature_suggestion_returns_dataclass_for_valid_input():
+    result = create_feature_suggestion("Dark Mode", "Add a dark theme for users.")
+
+    assert result.title == "Dark Mode"
+    assert result.summary == "Add a dark theme for users."
+
+
+def test_create_feature_suggestion_allows_max_title_length():
+    result = create_feature_suggestion("A" * 256, "Short summary")
+
+    assert result.title == "A" * 256
+
+
+def test_create_feature_suggestion_raises_for_title_too_long():
+    with pytest.raises(ValueError, match="The title cannot exceed 256 characters."):
+        create_feature_suggestion("A" * 257, "Short summary")
+
+
+def test_create_feature_suggestion_allows_max_summary_length():
+    result = create_feature_suggestion("Dark Mode", "B" * 1024)
+
+    assert result.summary == "B" * 1024
+
+
+def test_create_feature_suggestion_raises_for_summary_too_long():
+    with pytest.raises(ValueError, match="The summary cannot exceed 1024 characters."):
+        create_feature_suggestion("Dark Mode", "B" * 1025)

--- a/tests/unit/test_interviewprompt_service.py
+++ b/tests/unit/test_interviewprompt_service.py
@@ -1,0 +1,11 @@
+import byte_bot.services.interviewprompt_service as interviewprompt
+
+
+def test_get_random_question_returns_choice_from_questions(monkeypatch):
+    monkeypatch.setattr(interviewprompt.random, "choice", lambda sequence: sequence[0])
+
+    result = interviewprompt.get_random_question()
+
+    assert result == interviewprompt.QUESTIONS[0]
+    assert "question" in result
+    assert "answer" in result

--- a/tests/unit/test_leetcode_service.py
+++ b/tests/unit/test_leetcode_service.py
@@ -1,0 +1,140 @@
+import pytest
+
+import byte_bot.services.leetcode_service as leetcode
+
+
+class MockResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+def test_get_leetcode_profile_returns_parsed_user(monkeypatch):
+    def fake_post(url, json):
+        return MockResponse(
+            {
+                "data": {
+                    "matchedUser": {
+                        "username": "niits",
+                        "profile": {
+                            "realName": "Niits Test",
+                            "ranking": 12345,
+                            "reputation": 10,
+                            "countryName": "Morocco",
+                        },
+                        "submitStats": {
+                            "acSubmissionNum": [
+                                {"difficulty": "Easy", "count": 50},
+                                {"difficulty": "Medium", "count": 40},
+                            ]
+                        },
+                    }
+                }
+            }
+        )
+
+    monkeypatch.setattr(leetcode.requests, "post", fake_post)
+
+    result = leetcode.get_leetcode_profile("niits")
+
+    assert result.username == "niits"
+    assert result.profile.real_name == "Niits Test"
+    assert result.profile.ranking == 12345
+    assert result.profile.reputation == 10
+    assert result.profile.country == "Morocco"
+    assert len(result.submissions) == 2
+    assert result.submissions[0].difficulty == "Easy"
+    assert result.submissions[0].count == 50
+
+
+def test_get_leetcode_profile_raises_for_unknown_username(monkeypatch):
+    def fake_post(url, json):
+        return MockResponse({"data": {"matchedUser": None}})
+
+    monkeypatch.setattr(leetcode.requests, "post", fake_post)
+
+    with pytest.raises(ValueError, match="Failed to find a leetcode user with that username"):
+        leetcode.get_leetcode_profile("unknownuser")
+
+
+def test_get_leetcode_daily_returns_problem(monkeypatch):
+    def fake_post(url, json):
+        return MockResponse(
+            {
+                "data": {
+                    "activeDailyCodingChallengeQuestion": {
+                        "date": "1111-11-11",
+                        "link": "/problems/test-title",
+                        "question": {
+                            "title": "testTitle",
+                            "titleSlug": "test-title",
+                            "difficulty": "Easy",
+                            "acRate": 1234,
+                            "questionFrontendId": "1234",
+                        },
+                    }
+                }
+            }
+        )
+
+    monkeypatch.setattr(leetcode.requests, "post", fake_post)
+
+    result = leetcode.get_leetcode_daily()
+
+    assert result["link"] == "/problems/test-title"
+    assert result["question"]["title"] == "testTitle"
+    assert result["question"]["difficulty"] == "Easy"
+
+
+def test_get_leetcode_daily_raises_when_problem_missing(monkeypatch):
+    def fake_post(url, json):
+        return MockResponse({"data": {"activeDailyCodingChallengeQuestion": None}})
+
+    monkeypatch.setattr(leetcode.requests, "post", fake_post)
+
+    with pytest.raises(ValueError, match="Failed to find a daily leetcode problem"):
+        leetcode.get_leetcode_daily()
+
+
+def test_get_leetcode_random_returns_filtered_problem(monkeypatch):
+    def fake_get(url):
+        return MockResponse(
+            {
+                "stat_status_pairs": [
+                    {
+                        "stat": {
+                            "question__title": "Wrong Difficulty",
+                            "question__title_slug": "wrong-difficulty",
+                        },
+                        "difficulty": {"level": 2},
+                    },
+                    {
+                        "stat": {
+                            "question__title": "Two Sum",
+                            "question__title_slug": "two-sum",
+                        },
+                        "difficulty": {"level": 1},
+                    },
+                ]
+            }
+        )
+
+    monkeypatch.setattr(leetcode.requests, "get", fake_get)
+    monkeypatch.setattr(leetcode.random, "choice", lambda sequence: sequence[0])
+
+    result = leetcode.get_leetcode_random("Easy")
+
+    assert result["stat"]["question__title"] == "Two Sum"
+    assert result["stat"]["question__title_slug"] == "two-sum"
+
+
+def test_get_leetcode_random_raises_when_difficulty_missing():
+    with pytest.raises(ValueError, match="You must provide a difficulty"):
+        leetcode.get_leetcode_random(None)
+
+
+def test_get_leetcode_random_raises_when_difficulty_invalid():
+    with pytest.raises(ValueError, match="You must provide a difficulty"):
+        leetcode.get_leetcode_random("Impossible")


### PR DESCRIPTION
Closes #35 
## Description

Migrates business logic out of `cogs` and into `services`, and updates the test suite to match that separation of concerns

This PR:
- moves LeetCode-related business logic into `byte_bot/services/leetcode_service.py`
- keeps cogs focused on Discord command handling, input/output formatting, and error presentation
- adds unit tests for service-layer logic
- narrows integration tests so they verify cog-to-service wiring rather than service internals
- adds integration coverage for the interview prompt command
- adds unit coverage for the remaining services

This brings the codebase closer to the intended architecture where:
- `cogs/` handles Discord-specific behavior
- `services/` handles business logic and raises Python exceptions
- unit tests cover service branches
- integration tests cover command integration and Discord responses

## Linked Issue

- [ISSUE-#35](https://github.com/byte-club-hq/byte-bot/issues/35) - Migrate business logic from cogs to services

## Testing Instructions

Run unit tests:

```bash
uv run -m pytest
```

## Checklist:

- [x] PR has a meaningful title and description. **NOT**: `Merge branch into main`
- [x] I have linked the relevant issue(s) that this PR addresses.
- [x] I have fully tested all features present in this PR
- [ ] I have updated any relevant documentation (if applicable).
- [x] This PR fully addresses the linked issue(s). If not, I have explained why in the PR description.
