### PR TITLE
feat(ISSUE #41): Cache role toggle memberships

### DIFF
--- a/.agent/CONTINUITY.md
+++ b/.agent/CONTINUITY.md
@@ -1,0 +1,8 @@
+[DECISIONS]
+- 2026-07-07T00:00Z [CODE] File-backed SQLite is the only supported persistence target; URI handling was removed.
+
+[PROGRESS]
+- 2026-07-07T00:00Z [CODE] Removed SQLite URI handling and `:memory:` special casing from `DatabaseService`.
+
+[OUTCOMES]
+- 2026-07-07T00:00Z [CODE] Tests now use temp file-backed SQLite only; runtime behavior matches file-path persistence only.

--- a/README.md
+++ b/README.md
@@ -33,8 +33,9 @@ To get started with developing Byte Bot locally, follow these steps:
          ```bash
          DISCORD_TOKEN=your_discord_bot_token_here
          FEATURE_FORUM_CHANNEL_ID=123456789012345678
-         DATABASE_PATH=database/byte_bot.db
          ```
+       SQLite is always stored in `database/byte_bot.db` relative to the project root.
+       When using Docker Compose, that file is persisted through the `./database:/app/database` volume mapping.
 
     3. **WARNING**: This token is unique to YOU and YOU ONLY. DO NOT commit this token to the repo, or you risk exposing
        your bot

--- a/byte_bot/__main__.py
+++ b/byte_bot/__main__.py
@@ -1,6 +1,5 @@
 import logging
 import os
-from pathlib import Path
 
 from dotenv import load_dotenv
 
@@ -13,12 +12,6 @@ log = logging.getLogger(__name__)
 def get_config() -> Config:
     discord_token = os.environ.get("DISCORD_TOKEN")
     forum_channel_id_str = os.environ.get("FEATURE_FORUM_CHANNEL_ID")
-
-    # Keep a local sqlite file by default so the bot can start without extra setup.
-    database_path = os.environ.get("DATABASE_PATH") or str(
-        Path(__file__).resolve().parents[1] / "database" / "byte_bot.db"
-    )
-
     role_channel_id_str = os.environ.get("ROLE_CHANNEL_ID")
 
     if not discord_token:  # Ensure the token is set before proceeding
@@ -41,7 +34,6 @@ def get_config() -> Config:
     return Config(
         DISCORD_TOKEN=discord_token,
         FEATURE_FORUM_CHANNEL_ID=forum_channel_id,
-        DATABASE_PATH=database_path,
         ROLE_CHANNEL_ID=role_channel_id,
     )
 

--- a/byte_bot/byte_bot.py
+++ b/byte_bot/byte_bot.py
@@ -26,6 +26,8 @@ class ByteBot(commands.Bot):
     load cogs, etc.
     """
 
+    DATABASE_PATH = Path(__file__).resolve().parents[1] / "database" / "byte_bot.db"
+
     def __init__(self, config):
         super().__init__(
             intents=INTENTS,
@@ -39,7 +41,7 @@ class ByteBot(commands.Bot):
 
         self.config = config
         self.feature_forum_channel_id = self.config.FEATURE_FORUM_CHANNEL_ID
-        self.database_service = DatabaseService(self.config.DATABASE_PATH)
+        self.database_service = DatabaseService(str(self.DATABASE_PATH))
         # Recording start time for uptime tracking
         self.start_time = datetime.now(timezone.utc)
 

--- a/byte_bot/cogs/role_toggle.py
+++ b/byte_bot/cogs/role_toggle.py
@@ -247,7 +247,37 @@ class RoleToggleCog(commands.Cog):
             log.exception("Could not add reaction %s to role-toggle message %s", panel.emoji, message.id)
             raise
 
+        await self._sync_panel_memberships(guild, panel)
         return True
+
+    async def _sync_panel_memberships(self, guild: discord.Guild, panel: RoleTogglePanel) -> None:
+        role = self._get_panel_role(guild, panel)
+        if role is None:
+            return
+
+        # ponytail: sync only cached users; add a manual full reconciliation command if Discord is edited outside the bot.
+        for membership in self.service.list_memberships(guild_id=guild.id, role_id=role.id):
+            member = guild.get_member(membership.user_id)
+            if member is None:
+                try:
+                    member = await guild.fetch_member(membership.user_id)
+                except discord.NotFound:
+                    log.info("Cached role-toggle user %s is no longer in guild '%s'", membership.user_id, guild.name)
+                    continue
+                except discord.HTTPException:
+                    log.warning("Could not fetch cached role-toggle user %s in guild '%s'", membership.user_id, guild.name)
+                    continue
+
+            has_role = role in member.roles
+            try:
+                if membership.should_have_role and not has_role:
+                    await member.add_roles(role, reason="Role-toggle startup sync")
+                elif not membership.should_have_role and has_role:
+                    await member.remove_roles(role, reason="Role-toggle startup sync")
+            except discord.Forbidden:
+                log.error("Missing permissions to sync '%s' for user %s", panel.role_name, membership.user_id)
+            except discord.HTTPException:
+                log.exception("Discord rejected sync for '%s' and user %s", panel.role_name, membership.user_id)
 
     @commands.hybrid_command(
         name="roletoggle_status", description="Show the role-toggle configuration for this server."
@@ -421,6 +451,8 @@ class RoleToggleCog(commands.Cog):
                 except discord.HTTPException:
                     await self._reply(ctx, "Deleted config, but failed to delete the Discord role (HTTP error).")
 
+        if panel.role_id is not None:
+            self.service.delete_memberships(guild_id=ctx.guild.id, role_id=panel.role_id)
         self.service.delete_panel(guild_id=ctx.guild.id, role_name=panel.role_name)
         await self._reply(ctx, f"Deleted role-toggle panel for role `{panel.role_name}`.")
 
@@ -446,6 +478,13 @@ class RoleToggleCog(commands.Cog):
             except discord.HTTPException:
                 log.warning("Could not fetch member %s in guild '%s'", user_id, guild.name)
                 return
+
+        self.service.set_membership(
+            guild_id=guild.id,
+            role_id=role.id,
+            user_id=user_id,
+            should_have_role=should_have_role,
+        )
 
         has_role = role in member.roles
         if should_have_role and not has_role:

--- a/byte_bot/cogs/role_toggle.py
+++ b/byte_bot/cogs/role_toggle.py
@@ -63,9 +63,7 @@ class RoleToggleCog(commands.Cog):
 
         channel = await self._get_text_channel(self._role_channel_id)
         if channel is None:
-            log.warning(
-                "ROLE_CHANNEL_ID %s is not a usable text channel; skipping role-toggle setup", self._role_channel_id
-            )
+            log.warning(f"ROLE_CHANNEL_ID {self._role_channel_id} is not a usable text channel; skipping role-toggle setup")
             return
 
         await self._setup_role_toggle_panels(channel.guild, channel)
@@ -84,17 +82,17 @@ class RoleToggleCog(commands.Cog):
                     title=DEFAULT_TOGGLE_TITLE,
                 )
             except discord.Forbidden:
-                log.error("Missing permissions to create default role-toggle panel in guild '%s'", guild.name)
+                log.error(f"Missing permissions to create default role-toggle panel in guild '{guild.name}'")
             except Exception:
-                log.exception("Failed to create default role-toggle panel in guild '%s'", guild.name)
+                log.exception(f"Failed to create default role-toggle panel in guild '{guild.name}'")
 
         for panel in existing_panels:
             try:
                 await self._update_existing_panel(guild, channel, panel)
             except discord.Forbidden:
-                log.error("Missing permissions to set up role-toggle panel in guild '%s'", guild.name)
+                log.error(f"Missing permissions to set up role-toggle panel in guild '{guild.name}'")
             except Exception:
-                log.exception("Failed to set up role-toggle panel in guild '%s'", guild.name)
+                log.exception(f"Failed to set up role-toggle panel in guild '{guild.name}'")
 
     async def _get_text_channel(self, channel_id: int) -> discord.TextChannel | None:
         channel = self.bot.get_channel(channel_id)
@@ -116,9 +114,9 @@ class RoleToggleCog(commands.Cog):
         try:
             return await self.bot.fetch_guild(guild_id)
         except discord.NotFound:
-            log.warning("Guild %s was not found while handling a role-toggle reaction", guild_id)
+            log.warning(f"Guild {guild_id} was not found while handling a role-toggle reaction")
         except discord.HTTPException:
-            log.exception("Failed to fetch guild %s while handling a role-toggle reaction", guild_id)
+            log.exception(f"Failed to fetch guild {guild_id} while handling a role-toggle reaction")
         return None
 
     async def _create_panel_role(self, guild: discord.Guild, role_name: str) -> discord.Role:
@@ -129,7 +127,7 @@ class RoleToggleCog(commands.Cog):
             return matching_roles[0]
 
         role = await guild.create_role(name=role_name, mentionable=True)
-        log.info("Created role '%s' in guild '%s'", role_name, guild.name)
+        log.info(f"Created role '{role_name}' in guild '{guild.name}'")
         return role
 
     async def _resolve_panel_role(self, guild: discord.Guild, panel: RoleTogglePanel) -> discord.Role:
@@ -139,26 +137,20 @@ class RoleToggleCog(commands.Cog):
                 return role
 
             log.warning(
-                "Stored Discord role id %s for panel '%s' was not found in guild '%s'; recreating/rebinding role",
-                panel.role_id,
-                panel.role_name,
-                guild.name,
+                f"Stored Discord role id {panel.role_id} for panel '{panel.role_name}' was not found in guild '{guild.name}'; recreating/rebinding role"
             )
 
         return await self._create_panel_role(guild, panel.role_name)
 
     def _get_panel_role(self, guild: discord.Guild, panel: RoleTogglePanel) -> discord.Role | None:
         if panel.role_id is None:
-            log.warning("Role-toggle panel '%s' has no stored Discord role id", panel.role_name)
+            log.warning(f"Role-toggle panel '{panel.role_name}' has no stored Discord role id")
             return None
 
         role = guild.get_role(panel.role_id)
         if role is None:
             log.warning(
-                "Stored Discord role id %s for panel '%s' was not found in guild '%s'",
-                panel.role_id,
-                panel.role_name,
-                guild.name,
+                f"Stored Discord role id {panel.role_id} for panel '{panel.role_name}' was not found in guild '{guild.name}'",
             )
         return role
 
@@ -223,7 +215,7 @@ class RoleToggleCog(commands.Cog):
             )
 
         if panel.message_id is None:
-            log.warning("Role-toggle panel '%s' has no stored Discord message id", panel.role_name)
+            log.warning(f"Role-toggle panel '{panel.role_name}' has no stored Discord message id")
             return False
 
         embed = _build_role_toggle_embed(title=panel.title, role_name=role.name, emoji=panel.emoji)
@@ -231,20 +223,20 @@ class RoleToggleCog(commands.Cog):
         try:
             message = await channel.fetch_message(panel.message_id)
         except discord.NotFound:
-            log.warning("Stored role-toggle message %s for panel '%s' was not found", panel.message_id, panel.role_name)
+            log.warning(f"Stored role-toggle message {panel.message_id} for panel '{panel.role_name}' was not found")
             return False
         except discord.Forbidden:
-            log.error("Forbidden fetching role-toggle message %s in #%s", panel.message_id, channel.name)
+            log.error(f"Forbidden fetching role-toggle message {panel.message_id} in #{channel.name}")
             return False
         except discord.HTTPException:
-            log.exception("HTTP error fetching role-toggle message %s in #%s", panel.message_id, channel.name)
+            log.exception(f"HTTP error fetching role-toggle message {panel.message_id} in #{channel.name}")
             return False
 
         await message.edit(embed=embed)
         try:
             await message.add_reaction(panel.emoji)
         except discord.HTTPException:
-            log.exception("Could not add reaction %s to role-toggle message %s", panel.emoji, message.id)
+            log.exception(f"Could not add reaction {panel.emoji} to role-toggle message {message.id}")
             raise
 
         await self._sync_panel_memberships(guild, panel)
@@ -262,10 +254,10 @@ class RoleToggleCog(commands.Cog):
                 try:
                     member = await guild.fetch_member(membership.user_id)
                 except discord.NotFound:
-                    log.info("Cached role-toggle user %s is no longer in guild '%s'", membership.user_id, guild.name)
+                    log.info(f"Cached role-toggle user {membership.user_id} is no longer in guild '{guild.name}'")
                     continue
                 except discord.HTTPException:
-                    log.warning("Could not fetch cached role-toggle user %s in guild '%s'", membership.user_id, guild.name)
+                    log.warning(f"Could not fetch cached role-toggle user {membership.user_id} in guild '{guild.name}'")
                     continue
 
             has_role = role in member.roles
@@ -275,9 +267,9 @@ class RoleToggleCog(commands.Cog):
                 elif not membership.should_have_role and has_role:
                     await member.remove_roles(role, reason="Role-toggle startup sync")
             except discord.Forbidden:
-                log.error("Missing permissions to sync '%s' for user %s", panel.role_name, membership.user_id)
+                log.error(f"Missing permissions to sync '{panel.role_name}' for user {membership.user_id}")
             except discord.HTTPException:
-                log.exception("Discord rejected sync for '%s' and user %s", panel.role_name, membership.user_id)
+                log.exception(f"Discord rejected sync for '{panel.role_name}' and user {membership.user_id}")
 
     @commands.hybrid_command(
         name="roletoggle_status", description="Show the role-toggle configuration for this server."
@@ -438,7 +430,7 @@ class RoleToggleCog(commands.Cog):
             except discord.NotFound:
                 pass
             except discord.HTTPException:
-                log.exception("Failed deleting role-toggle message %s", panel.message_id)
+                log.exception(f"Failed deleting role-toggle message {panel.message_id}")
 
         if delete_discord_role:
             # This deletes the real Discord role (removes it from everyone).
@@ -468,7 +460,7 @@ class RoleToggleCog(commands.Cog):
     ) -> None:
         role = self._get_panel_role(guild, panel)
         if role is None:
-            log.warning("Role '%s' does not exist in guild '%s'", panel.role_name, guild.name)
+            log.warning(f"Role '{panel.role_name}' does not exist in guild '{guild.name}'")
             return
 
         member = guild.get_member(user_id)
@@ -476,7 +468,7 @@ class RoleToggleCog(commands.Cog):
             try:
                 member = await guild.fetch_member(user_id)
             except discord.HTTPException:
-                log.warning("Could not fetch member %s in guild '%s'", user_id, guild.name)
+                log.warning(f"Could not fetch member {user_id} in guild '{guild.name}'")
                 return
 
         self.service.set_membership(
@@ -518,9 +510,9 @@ class RoleToggleCog(commands.Cog):
         try:
             await self._toggle_role_for_member(guild=guild, user_id=payload.user_id, panel=panel, should_have_role=True)
         except discord.Forbidden:
-            log.error("Missing permissions to add '%s' via reactions", panel.role_name)
+            log.error(f"Missing permissions to add '{panel.role_name}' via reactions")
         except Exception:
-            log.exception("Failed to add '%s' via reaction", panel.role_name)
+            log.exception(f"Failed to add '{panel.role_name}' via reaction")
 
     @commands.Cog.listener()
     async def on_raw_reaction_remove(self, payload: discord.RawReactionActionEvent) -> None:
@@ -548,9 +540,9 @@ class RoleToggleCog(commands.Cog):
                 guild=guild, user_id=payload.user_id, panel=panel, should_have_role=False
             )
         except discord.Forbidden:
-            log.error("Missing permissions to remove '%s' via reactions", panel.role_name)
+            log.error(f"Missing permissions to remove '{panel.role_name}' via reactions")
         except Exception:
-            log.exception("Failed to remove '%s' via reaction", panel.role_name)
+            log.exception(f"Failed to remove '{panel.role_name}' via reaction")
 
 
 async def setup(bot: ByteBot) -> None:

--- a/byte_bot/config.py
+++ b/byte_bot/config.py
@@ -5,5 +5,4 @@ from typing import Optional
 class Config:
     DISCORD_TOKEN: str
     FEATURE_FORUM_CHANNEL_ID: int
-    DATABASE_PATH: str
     ROLE_CHANNEL_ID: Optional[int] = None

--- a/byte_bot/services/database_service.py
+++ b/byte_bot/services/database_service.py
@@ -71,6 +71,19 @@ class DatabaseService:
                     """
                 )
 
+                connection.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS role_toggle_memberships (
+                        guild_id INTEGER NOT NULL,
+                        role_id INTEGER NOT NULL,
+                        user_id INTEGER NOT NULL,
+                        should_have_role INTEGER NOT NULL,
+                        updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                        PRIMARY KEY (guild_id, role_id, user_id)
+                    )
+                    """
+                )
+
     def upsert_user(
         self,
         *,

--- a/byte_bot/services/database_service.py
+++ b/byte_bot/services/database_service.py
@@ -17,18 +17,13 @@ class UserRecord:
 class DatabaseService:
     def __init__(self, database_path: str):
         self.database_path = database_path
-        # sqlite treats values like "file:..." as connection URIs, not plain file paths.
-        self._is_uri = database_path.startswith("file:")
         self.initialize()
 
     def _create_connection(self) -> sqlite3.Connection:
-        # ":memory:" tells sqlite to keep everything in RAM for this connection only,
-        # so there is no parent directory or database file to create on disk.
-        if not self._is_uri and self.database_path != ":memory:":
-            Path(self.database_path).parent.mkdir(parents=True, exist_ok=True)
+        Path(self.database_path).parent.mkdir(parents=True, exist_ok=True)
 
         try:
-            connection = sqlite3.connect(self.database_path, uri=self._is_uri)
+            connection = sqlite3.connect(self.database_path)
         except sqlite3.OperationalError as exc:
             raise sqlite3.OperationalError(
                 f"Unable to open SQLite database at {self.database_path!r}. "
@@ -47,8 +42,7 @@ class DatabaseService:
 
     def initialize(self) -> None:
         # Safe to call on every startup; this only creates the table if it's missing.
-        if not self._is_uri and self.database_path != ":memory:":
-            log.info("Initializing SQLite database at %s", Path(self.database_path).resolve())
+        log.info("Initializing SQLite database at %s", Path(self.database_path).resolve())
 
         with self.get_connection() as connection:
             with connection:
@@ -96,8 +90,7 @@ class DatabaseService:
                     """
                 )
 
-        if not self._is_uri and self.database_path != ":memory:":
-            log.info("SQLite database ready at %s", Path(self.database_path).resolve())
+        log.info("SQLite database ready at %s", Path(self.database_path).resolve())
 
     def upsert_user(
         self,

--- a/byte_bot/services/database_service.py
+++ b/byte_bot/services/database_service.py
@@ -1,7 +1,10 @@
 from contextlib import contextmanager
 from dataclasses import dataclass
+import logging
 from pathlib import Path
 import sqlite3
+
+log = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -24,7 +27,13 @@ class DatabaseService:
         if not self._is_uri and self.database_path != ":memory:":
             Path(self.database_path).parent.mkdir(parents=True, exist_ok=True)
 
-        connection = sqlite3.connect(self.database_path, uri=self._is_uri)
+        try:
+            connection = sqlite3.connect(self.database_path, uri=self._is_uri)
+        except sqlite3.OperationalError as exc:
+            raise sqlite3.OperationalError(
+                f"Unable to open SQLite database at {self.database_path!r}. "
+                "Check that the path is writable and, in Docker, mounted where you expect."
+            ) from exc
         connection.row_factory = sqlite3.Row
         return connection
 
@@ -38,6 +47,9 @@ class DatabaseService:
 
     def initialize(self) -> None:
         # Safe to call on every startup; this only creates the table if it's missing.
+        if not self._is_uri and self.database_path != ":memory:":
+            log.info("Initializing SQLite database at %s", Path(self.database_path).resolve())
+
         with self.get_connection() as connection:
             with connection:
                 connection.execute(
@@ -83,6 +95,9 @@ class DatabaseService:
                     )
                     """
                 )
+
+        if not self._is_uri and self.database_path != ":memory:":
+            log.info("SQLite database ready at %s", Path(self.database_path).resolve())
 
     def upsert_user(
         self,

--- a/byte_bot/services/role_toggle_service.py
+++ b/byte_bot/services/role_toggle_service.py
@@ -16,6 +16,14 @@ class RoleTogglePanel:
     title: str
 
 
+@dataclass(frozen=True)
+class RoleToggleMembership:
+    guild_id: int
+    role_id: int
+    user_id: int
+    should_have_role: bool
+
+
 DEFAULT_ROLE_NAME = "ByteClubHQ"
 DEFAULT_TOGGLE_EMOJI = "\u2705"
 DEFAULT_TOGGLE_TITLE = "ByteClubHQ Access"
@@ -102,6 +110,53 @@ class RoleToggleService:
                     WHERE guild_id = ? AND role_name = ?
                     """,
                     (guild_id, role_name),
+                )
+
+    def set_membership(self, *, guild_id: int, role_id: int, user_id: int, should_have_role: bool) -> None:
+        with self.database_service.get_connection() as connection:
+            with connection:
+                connection.execute(
+                    """
+                    INSERT INTO role_toggle_memberships (guild_id, role_id, user_id, should_have_role, updated_at)
+                    VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)
+                    ON CONFLICT(guild_id, role_id, user_id) DO UPDATE SET
+                        should_have_role = excluded.should_have_role,
+                        updated_at = CURRENT_TIMESTAMP
+                    """,
+                    (guild_id, role_id, user_id, int(should_have_role)),
+                )
+
+    def list_memberships(self, *, guild_id: int, role_id: int) -> list[RoleToggleMembership]:
+        with self.database_service.get_connection() as connection:
+            rows = connection.execute(
+                """
+                SELECT guild_id, role_id, user_id, should_have_role
+                FROM role_toggle_memberships
+                WHERE guild_id = ? AND role_id = ?
+                ORDER BY user_id ASC
+                """,
+                (guild_id, role_id),
+            ).fetchall()
+
+        return [
+            RoleToggleMembership(
+                guild_id=row["guild_id"],
+                role_id=row["role_id"],
+                user_id=row["user_id"],
+                should_have_role=bool(row["should_have_role"]),
+            )
+            for row in rows
+        ]
+
+    def delete_memberships(self, *, guild_id: int, role_id: int) -> None:
+        with self.database_service.get_connection() as connection:
+            with connection:
+                connection.execute(
+                    """
+                    DELETE FROM role_toggle_memberships
+                    WHERE guild_id = ? AND role_id = ?
+                    """,
+                    (guild_id, role_id),
                 )
 
     def find_matching_panel(self, *, guild_id: int, message_id: int, emoji: str) -> RoleTogglePanel | None:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,5 +5,3 @@ services:
       - ".env"
     volumes:
       - ./database:/app/database
-    environment:
-      - DISCORD_TOKEN=${DISCORD_TOKEN}

--- a/example.env
+++ b/example.env
@@ -3,5 +3,3 @@
 DISCORD_TOKEN=
 FEATURE_FORUM_CHANNEL_ID=
 ROLE_CHANNEL_ID=
-# Optional. Defaults to ./database/byte_bot.db -- if you change default value.. dont forget to update volumes in docker compose
-DATABASE_PATH=

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,9 +24,10 @@ def database_path(tmp_path):
 async def bot(database_path):
     test_config = SimpleNamespace(
         FEATURE_FORUM_CHANNEL_ID=1234567890,
-        DATABASE_PATH=database_path,
         ROLE_CHANNEL_ID=9876543210,
     )
+    original_database_path = ByteBot.DATABASE_PATH
+    ByteBot.DATABASE_PATH = Path(database_path)
     bot = ByteBot(config=test_config)
     dpytest.configure(bot)
     
@@ -41,4 +42,5 @@ async def bot(database_path):
     try:
         yield bot
     finally:
+        ByteBot.DATABASE_PATH = original_database_path
         await dpytest.empty_queue()

--- a/tests/unit/test_byte_bot.py
+++ b/tests/unit/test_byte_bot.py
@@ -5,9 +5,6 @@ from byte_bot.byte_bot import health_check
 class BotConfig:
     FEATURE_FORUM_CHANNEL_ID = 1234567890
 
-    def __init__(self, database_path: str):
-        self.DATABASE_PATH = database_path
-
 
 def test_health_check_returns_ok_status():
     result = health_check()
@@ -15,15 +12,20 @@ def test_health_check_returns_ok_status():
 
 
 def test_byte_bot_initializes_database_service(tmp_path):
-    bot = ByteBot(BotConfig(str(tmp_path / "byte_bot.db")))
+    original_database_path = ByteBot.DATABASE_PATH
+    ByteBot.DATABASE_PATH = tmp_path / "byte_bot.db"
+    bot = ByteBot(BotConfig())
 
-    with bot.database_service.get_connection() as connection:
-        table = connection.execute(
-            """
-            SELECT name
-            FROM sqlite_master
-            WHERE type = 'table' AND name = 'users'
-            """
-        ).fetchone()
+    try:
+        with bot.database_service.get_connection() as connection:
+            table = connection.execute(
+                """
+                SELECT name
+                FROM sqlite_master
+                WHERE type = 'table' AND name = 'users'
+                """
+            ).fetchone()
+    finally:
+        ByteBot.DATABASE_PATH = original_database_path
 
     assert table["name"] == "users"

--- a/tests/unit/test_database_service.py
+++ b/tests/unit/test_database_service.py
@@ -29,6 +29,21 @@ def test_database_service_initializes_role_toggle_role_id_column(database_path):
     assert "role_id" in {column["name"] for column in columns}
 
 
+def test_database_service_initializes_role_toggle_memberships_table(database_path):
+    database_service = DatabaseService(database_path)
+
+    with database_service.get_connection() as connection:
+        table = connection.execute(
+            """
+            SELECT name
+            FROM sqlite_master
+            WHERE type = 'table' AND name = 'role_toggle_memberships'
+            """
+        ).fetchone()
+
+    assert table["name"] == "role_toggle_memberships"
+
+
 def test_database_service_upserts_and_reads_user(database_path):
     database_service = DatabaseService(database_path)
 

--- a/tests/unit/test_role_toggle_cog.py
+++ b/tests/unit/test_role_toggle_cog.py
@@ -162,7 +162,7 @@ async def test_update_existing_panel_refreshes_missing_role_id():
         upserted.append(kwargs)
         return RoleTogglePanel(**kwargs)
 
-    cog.service = SimpleNamespace(upsert_panel=upsert_panel)
+    cog.service = SimpleNamespace(upsert_panel=upsert_panel, list_memberships=lambda **kwargs: [])
     guild = SimpleNamespace(
         id=1,
         name="Byte Club",
@@ -184,3 +184,36 @@ async def test_update_existing_panel_refreshes_missing_role_id():
     assert upserted[0]["role_id"] == created_role.id
     assert reactions == ["✅"]
     assert edited_messages
+
+
+@pytest.mark.asyncio
+async def test_toggle_role_records_membership_before_role_change():
+    cog = _cog_without_bot()
+    role = SimpleNamespace(id=100, name="ByteClubHQ")
+    added_roles = []
+    memberships = []
+
+    async def add_roles(role_to_add, reason: str):
+        added_roles.append((role_to_add, reason))
+
+    member = SimpleNamespace(id=200, roles=[], add_roles=add_roles)
+    guild = SimpleNamespace(
+        id=1,
+        name="Byte Club",
+        get_role=lambda role_id: role if role_id == role.id else None,
+        get_member=lambda user_id: member if user_id == member.id else None,
+    )
+    panel = RoleTogglePanel(
+        guild_id=1,
+        message_id=2,
+        role_id=role.id,
+        role_name="ByteClubHQ",
+        emoji="âœ…",
+        title="ByteClubHQ Access",
+    )
+    cog.service = SimpleNamespace(set_membership=lambda **kwargs: memberships.append(kwargs))
+
+    await cog._toggle_role_for_member(guild=guild, user_id=member.id, panel=panel, should_have_role=True)
+
+    assert memberships == [{"guild_id": 1, "role_id": 100, "user_id": 200, "should_have_role": True}]
+    assert added_roles == [(role, "User reacted to role toggle message")]

--- a/tests/unit/test_role_toggle_service.py
+++ b/tests/unit/test_role_toggle_service.py
@@ -82,3 +82,38 @@ def test_role_toggle_service_deletes_panel(database_path):
     service.delete_panel(guild_id=123, role_name="ByteClubHQ")
 
     assert service.get_panel(123, role_name="ByteClubHQ") is None
+
+
+def test_role_toggle_service_tracks_membership_state(database_path):
+    service = RoleToggleService(DatabaseService(database_path))
+
+    service.set_membership(guild_id=123, role_id=456, user_id=789, should_have_role=True)
+    service.set_membership(guild_id=123, role_id=456, user_id=999, should_have_role=False)
+
+    memberships = service.list_memberships(guild_id=123, role_id=456)
+
+    assert [membership.user_id for membership in memberships] == [789, 999]
+    assert memberships[0].should_have_role is True
+    assert memberships[1].should_have_role is False
+
+
+def test_role_toggle_service_updates_membership_state(database_path):
+    service = RoleToggleService(DatabaseService(database_path))
+
+    service.set_membership(guild_id=123, role_id=456, user_id=789, should_have_role=True)
+    service.set_membership(guild_id=123, role_id=456, user_id=789, should_have_role=False)
+
+    [membership] = service.list_memberships(guild_id=123, role_id=456)
+
+    assert membership.should_have_role is False
+
+
+def test_role_toggle_service_deletes_memberships_for_role(database_path):
+    service = RoleToggleService(DatabaseService(database_path))
+    service.set_membership(guild_id=123, role_id=456, user_id=789, should_have_role=True)
+    service.set_membership(guild_id=123, role_id=999, user_id=789, should_have_role=True)
+
+    service.delete_memberships(guild_id=123, role_id=456)
+
+    assert service.list_memberships(guild_id=123, role_id=456) == []
+    assert len(service.list_memberships(guild_id=123, role_id=999)) == 1


### PR DESCRIPTION
Close #41 

## Description:

This PR adds a SQLite-backed membership cache for the role-toggle project roles.

When someone adds or removes a reaction, we now store the intended role state for that user. On startup, panel sync uses that cached state to repair roles after a bot restart without having to scan every member in the server.

I used `should_have_role` instead of only storing current role holders so removals can be recovered too. For example, if a reaction removal is recorded but the bot crashes before Discord finishes removing the role, the cached `should_have_role = false` value gives us enough information to clean that up on the next startup. Those rows are there on purpose as recovery state.

Also cleaned up the database setup a bit. The bot now always uses `database/byte_bot.db` instead of relying on a configurable DB path, and Docker Compose mounts `./database` straight to `/app/database`. Added startup logging around SQLite init too, so if something goes wrong it should be a lot easier to see which path the bot is trying to use and why it failed.

This still keeps the existing single role-toggle channel setup and the current `Manage Server` permission check for creating and deleting role-toggle panels.

## Linked Issue:

- [ISSUE-41](https://github.com/byte-club-hq/byte-bot/issues/41) - Extend role services for per-project opt-in roles


## Testing Instructions:

1. Run the unit/integration suite:
   ```bash
   python -m pytest
   ```
2. Run lint on the changed files:
   ```bash
   python -m ruff check byte_bot/cogs/role_toggle.py byte_bot/services/database_service.py byte_bot/services/role_toggle_service.py tests/unit/test_database_service.py tests/unit/test_role_toggle_cog.py tests/unit/test_role_toggle_service.py
   ```
3. Start the bot locally with `ROLE_CHANNEL_ID` set.
4. React to an existing role-toggle panel and confirm the Discord role is added.
5. Remove the reaction and confirm the Discord role is removed.
6. Confirm `role_toggle_memberships` exists in the configured SQLite database and contains the cached intended membership state.
7. Restart the bot and confirm existing role-toggle panels still load successfully.
8. Confirm the bot writes SQLite data to `database/byte_bot.db` and logs the resolved database path during startup.

## Checklist:

- [x] PR has a meaningful title and description. **NOT**: `Merge branch into main`
- [x] I have linked the relevant issue(s) that this PR addresses.
- [x] I have fully tested all features present in this PR
- [x] I have updated any relevant documentation (if applicable).
- [x] This PR fully addresses the linked issue(s). If not, I have explained why in the PR description.
