### PR TITLE
Issue #43 Feat/suggestfeature image

### DIFF
--- a/byte_bot/cogs/feature_suggest.py
+++ b/byte_bot/cogs/feature_suggest.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Optional
+from typing import Annotated
 
 import discord
 from discord.ext import commands
@@ -16,7 +16,7 @@ class ImageURL(commands.Converter):
     """Convert a command argument to an image URL, or reject it.
 
     Raising ``BadArgument`` on a non-URL token is deliberate. For an
-    ``Optional[ImageURL]`` parameter, discord.py's prefix parser catches the
+    ``ImageURL | None`` parameter, discord.py's prefix parser catches the
     error, rewinds the string view (``view.undo()``), sets ``image`` to
     ``None``, and lets the rewound token fall through to the consume-rest
     ``summary`` parameter. So a URL is captured as the image, and any other
@@ -24,7 +24,7 @@ class ImageURL(commands.Converter):
     """
 
     async def convert(self, ctx: commands.Context, argument: str) -> str:
-        if not argument.startswith("https://"):
+        if not argument.startswith(("http://", "https://")):
             raise commands.BadArgument("Not an image URL.")
         return argument
 
@@ -88,7 +88,7 @@ class FeatureSuggest(commands.Cog):
         summary='A short summary of your feature. To attach a picture, also pick the optional "image" option.',
         image='Optional DIRECT image link (must end in .png/.jpg/.gif).'
     )
-    async def suggest_feature(self, ctx: commands.Context, title: str, image: Optional[ImageURL] = None, *, summary: str) -> None:
+    async def suggest_feature(self, ctx: commands.Context, title: str, image: Annotated[str, ImageURL] | None, *, summary: str) -> None:
         """
         Submit a feature suggestion to the forum channel.
 
@@ -194,7 +194,7 @@ class FeatureSuggest(commands.Cog):
         elif isinstance(error, commands.BadArgument):
             await self._reply(
                 ctx,
-                "❌ The **image** option must be a direct image link starting with https://.",
+                "❌ The **image** option must be a direct image link starting with http:// or https://.",
             )
 
 async def setup(bot: ByteBot):

--- a/byte_bot/cogs/feature_suggest.py
+++ b/byte_bot/cogs/feature_suggest.py
@@ -139,7 +139,8 @@ class FeatureSuggest(commands.Cog):
             color=discord.Color.brand_red(),
         )
         embed.add_field(name="Title", value=f"{suggestion.title}", inline=False)
-        embed.add_field(name="Summary", value=f"{suggestion.summary}", inline=False)
+        for i, chunk in enumerate(suggestion.summary_chunked):
+            embed.add_field(name="Summary" if i == 0 else "​", value=chunk, inline=False)
         if suggestion.image:
             embed.set_image(url=suggestion.image)
         embed.set_footer(text=f"Requested by {ctx.author.display_name}", icon_url=icon_url)

--- a/byte_bot/cogs/feature_suggest.py
+++ b/byte_bot/cogs/feature_suggest.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Optional
 
 import discord
 from discord.ext import commands
@@ -9,6 +10,24 @@ from byte_bot.services.feature_suggest_service import create_feature_suggestion
 
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
+
+
+class ImageURL(commands.Converter):
+    """Convert a command argument to an image URL, or reject it.
+
+    Raising ``BadArgument`` on a non-URL token is deliberate. For an
+    ``Optional[ImageURL]`` parameter, discord.py's prefix parser catches the
+    error, rewinds the string view (``view.undo()``), sets ``image`` to
+    ``None``, and lets the rewound token fall through to the consume-rest
+    ``summary`` parameter. So a URL is captured as the image, and any other
+    word is handed back to the summary instead of being stolen.
+    """
+
+    async def convert(self, ctx: commands.Context, argument: str) -> str:
+        if not argument.startswith("https://"):
+            raise commands.BadArgument("Not an image URL.")
+        return argument
+
 
 class FeatureSuggest(commands.Cog):
     """
@@ -66,9 +85,10 @@ class FeatureSuggest(commands.Cog):
     @commands.hybrid_command(name="suggestfeature", description="Submit a feature suggestion.")
     @app_commands.describe(
         title='The title of your feature. Example (text command use quotes): "Dark Mode"',
-        summary='A short summary describing your feature.'
+        summary='A short summary of your feature. To attach a picture, also pick the optional "image" option.',
+        image='Optional DIRECT image link (must end in .png/.jpg/.gif).'
     )
-    async def suggest_feature(self, ctx: commands.Context, title: str, *, summary: str) -> None:
+    async def suggest_feature(self, ctx: commands.Context, title: str, image: Optional[ImageURL] = None, *, summary: str) -> None:
         """
         Submit a feature suggestion to the forum channel.
 
@@ -84,6 +104,9 @@ class FeatureSuggest(commands.Cog):
                 Multi-word titles in the text commands must be wrapped in quotes.
             summary (str): A brief description of the feature request. Max 1024 
                 characters.
+            image (Optional[ImageURL]): An optional direct image URL to attach to the embed.
+                For prefixed commands, if no URL is provided, the first message attachment
+                will be used if available.
 
         Returns: 
             None: Sends messages directly to Discord channels and/or users.
@@ -92,8 +115,11 @@ class FeatureSuggest(commands.Cog):
             discord.DiscordException: If sending the embed or creating the thread
                 fails due to permissions or other Discord API issues.
         """
+        if image is None and ctx.message.attachments:
+            image = ctx.message.attachments[0].url
+
         try:
-            suggestion = create_feature_suggestion(title, summary)
+            suggestion = create_feature_suggestion(title, summary, image)
         except ValueError as error:
             await self._reply(ctx, str(error))
             return
@@ -114,6 +140,8 @@ class FeatureSuggest(commands.Cog):
         )
         embed.add_field(name="Title", value=f"{suggestion.title}", inline=False)
         embed.add_field(name="Summary", value=f"{suggestion.summary}", inline=False)
+        if suggestion.image:
+            embed.set_image(url=suggestion.image)
         embed.set_footer(text=f"Requested by {ctx.author.display_name}", icon_url=icon_url)
 
         # --- Send embed to forum thread ---
@@ -151,7 +179,10 @@ class FeatureSuggest(commands.Cog):
             None: Sends either an ephemeral message (slash command) or a DM
             (text command) to the user.
         """
-        if isinstance(error, commands.MissingRequiredArgument) and ctx.command.name == "suggestfeature":
+        if ctx.command is None or ctx.command.name != "suggestfeature":
+            return
+
+        if isinstance(error, commands.MissingRequiredArgument):
             message = (
                 "❌ You must provide both a **title** and a **summary**.\n\n"
                     "**How to use:**\n"
@@ -160,6 +191,11 @@ class FeatureSuggest(commands.Cog):
                     "Make sure to put quotes around multi-word titles for text commands!"
             )
             await self._reply(ctx, message)
+        elif isinstance(error, commands.BadArgument):
+            await self._reply(
+                ctx,
+                "❌ The **image** option must be a direct image link starting with https://.",
+            )
 
 async def setup(bot: ByteBot):
     await bot.add_cog(FeatureSuggest(bot))

--- a/byte_bot/services/feature_suggest_service.py
+++ b/byte_bot/services/feature_suggest_service.py
@@ -1,12 +1,11 @@
 from dataclasses import dataclass
-from typing import Optional
 
 
 @dataclass(frozen=True)
 class FeatureSuggestion:
     title: str
     summary: str
-    image: Optional[str] = None
+    image: str | None = None
 
     def __post_init__(self):
         if len(self.title) > 256:
@@ -18,5 +17,5 @@ class FeatureSuggestion:
                 raise ValueError("Image URL must be a direct link starting with http:// or https://")
 
 
-def create_feature_suggestion(title: str, summary: str, image: Optional[str] = None) -> FeatureSuggestion:
+def create_feature_suggestion(title: str, summary: str, image: str | None = None) -> FeatureSuggestion:
     return FeatureSuggestion(title=title, summary=summary, image=image)

--- a/byte_bot/services/feature_suggest_service.py
+++ b/byte_bot/services/feature_suggest_service.py
@@ -1,17 +1,22 @@
 from dataclasses import dataclass
+from typing import Optional
 
 
 @dataclass(frozen=True)
 class FeatureSuggestion:
     title: str
     summary: str
+    image: Optional[str] = None
 
     def __post_init__(self):
         if len(self.title) > 256:
             raise ValueError("The title cannot exceed 256 characters.")
         if len(self.summary) > 1024:
             raise ValueError("The summary cannot exceed 1024 characters.")
+        if self.image is not None: 
+            if not self.image.startswith("https://"):
+                raise ValueError("Image URL must be a direct link starting with https://")
 
 
-def create_feature_suggestion(title: str, summary: str) -> FeatureSuggestion:
-    return FeatureSuggestion(title=title, summary=summary)
+def create_feature_suggestion(title: str, summary: str, image: Optional[str] = None) -> FeatureSuggestion:
+    return FeatureSuggestion(title=title, summary=summary, image=image)

--- a/byte_bot/services/feature_suggest_service.py
+++ b/byte_bot/services/feature_suggest_service.py
@@ -1,20 +1,41 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from typing import Final
 
 
-@dataclass(frozen=True)
+@dataclass
 class FeatureSuggestion:
     title: str
     summary: str
     image: str | None = None
+    summary_chunked: list[str] = field(init=False, repr=False, default_factory=list)
 
     def __post_init__(self):
         if len(self.title) > 256:
             raise ValueError("The title cannot exceed 256 characters.")
-        if len(self.summary) > 1024:
-            raise ValueError("The summary cannot exceed 1024 characters.")
         if self.image is not None: 
             if not self.image.startswith(("http://", "https://")):
                 raise ValueError("Image URL must be a direct link starting with http:// or https://")
+        self._chunk_text()
+
+    def _chunk_text(self) -> None:
+        field_text_max: Final[int] = 1024
+        if len(self.summary) <= field_text_max: # Early return for a short enough message
+            self.summary_chunked = [self.summary]
+            return
+        
+        words: list[str] = self.summary.split()
+        chunks: list[str] = []
+        current: str = words[0]
+
+        for w in words[1:]:
+            if len(current) + 1 + len(w) <= field_text_max: # +1 for the space
+                current = current + " " + w
+            else:
+                chunks.append(current)
+                current = w
+        chunks.append(current)
+
+        self.summary_chunked = chunks
 
 
 def create_feature_suggestion(title: str, summary: str, image: str | None = None) -> FeatureSuggestion:

--- a/byte_bot/services/feature_suggest_service.py
+++ b/byte_bot/services/feature_suggest_service.py
@@ -14,8 +14,8 @@ class FeatureSuggestion:
         if len(self.summary) > 1024:
             raise ValueError("The summary cannot exceed 1024 characters.")
         if self.image is not None: 
-            if not self.image.startswith("https://"):
-                raise ValueError("Image URL must be a direct link starting with https://")
+            if not self.image.startswith(("http://", "https://")):
+                raise ValueError("Image URL must be a direct link starting with http:// or https://")
 
 
 def create_feature_suggestion(title: str, summary: str, image: Optional[str] = None) -> FeatureSuggestion:

--- a/tests/integration/test_suggest_feature.py
+++ b/tests/integration/test_suggest_feature.py
@@ -255,3 +255,24 @@ async def test_suggestfeature_attachment_used_when_no_url(bot, monkeypatch):
 
     embed = mock_channel.create_thread.call_args[1]["embed"]
     assert embed.image.url == "https://cdn.discordapp.com/x.png"
+
+
+@pytest.mark.asyncio
+async def test_suggestfeature_long_summary_split_across_fields(bot, monkeypatch):
+    _block_dms(monkeypatch)
+    mock_channel = _make_forum_channel()
+    monkeypatch.setattr(bot, "get_channel", lambda _: mock_channel)
+    _patch_feature_service(
+        monkeypatch,
+        bot,
+        lambda title, summary, image=None: FeatureSuggestion(title=title, summary=summary, image=image),
+    )
+
+    summary = " ".join(["word"] * 300)  # ~1499 chars, forces multiple chunks
+    await dpytest.message(f'+suggestfeature "Dark Mode" {summary}')
+
+    embed = mock_channel.create_thread.call_args[1]["embed"]
+    summary_fields = [f for f in embed.fields if f.name in ("Summary", "​")]
+    assert len(summary_fields) > 1
+    assert all(len(f.value) <= 1024 for f in summary_fields)
+    assert " ".join(f.value for f in summary_fields) == summary

--- a/tests/integration/test_suggest_feature.py
+++ b/tests/integration/test_suggest_feature.py
@@ -40,7 +40,7 @@ async def test_suggestfeature_created_thread(bot, monkeypatch):
     _patch_feature_service(
         monkeypatch,
         bot,
-        lambda title, summary: FeatureSuggestion(title=title, summary=summary),
+        lambda title, summary, image: FeatureSuggestion(title=title, summary=summary, image=image),
     )
 
     await dpytest.message('+suggestfeature "Dark Mode" Add a dark theme for users.')
@@ -59,7 +59,7 @@ async def test_suggestfeature_sends_confirmation(bot, monkeypatch):
     _patch_feature_service(
         monkeypatch,
         bot,
-        lambda title, summary: FeatureSuggestion(title=title, summary=summary),
+        lambda title, summary, image: FeatureSuggestion(title=title, summary=summary, image=image),
     )
 
     await dpytest.message('+suggestfeature "Dark Mode" Add a dark theme for users.')
@@ -75,7 +75,7 @@ async def test_suggestfeature_single_word_title(bot, monkeypatch):
     _patch_feature_service(
         monkeypatch,
         bot,
-        lambda title, summary: FeatureSuggestion(title=title, summary=summary),
+        lambda title, summary, image: FeatureSuggestion(title=title, summary=summary, image=image),
     )
 
     await dpytest.message("+suggestfeature Notifications Add push notifications.")
@@ -89,7 +89,7 @@ async def test_suggestfeature_service_error_is_reported(bot, monkeypatch):
     mock_channel = _make_forum_channel()
     monkeypatch.setattr(bot, "get_channel", lambda _: mock_channel)
 
-    def raise_value_error(title, summary):
+    def raise_value_error(title, summary, image):
         raise ValueError("The title cannot exceed 256 characters.")
 
     _patch_feature_service(monkeypatch, bot, raise_value_error)
@@ -127,7 +127,7 @@ async def test_suggestfeature_channel_not_found(bot, monkeypatch):
     _patch_feature_service(
         monkeypatch,
         bot,
-        lambda title, summary: FeatureSuggestion(title=title, summary=summary),
+        lambda title, summary, image: FeatureSuggestion(title=title, summary=summary, image=image),
     )
 
     await dpytest.message('+suggestfeature "Dark Mode" Some summary.')
@@ -142,7 +142,7 @@ async def test_suggestfeature_wrong_channel_type(bot, monkeypatch):
     _patch_feature_service(
         monkeypatch,
         bot,
-        lambda title, summary: FeatureSuggestion(title=title, summary=summary),
+        lambda title, summary, image: FeatureSuggestion(title=title, summary=summary, image=image),
     )
 
     await dpytest.message('+suggestfeature "Dark Mode" Some summary.')
@@ -159,7 +159,7 @@ async def test_suggestfeature_wrong_channel_type_no_thread_created(bot, monkeypa
     _patch_feature_service(
         monkeypatch,
         bot,
-        lambda title, summary: FeatureSuggestion(title=title, summary=summary),
+        lambda title, summary, image: FeatureSuggestion(title=title, summary=summary, image=image),
     )
 
     await dpytest.message('+suggestfeature "Dark Mode" Some summary.')
@@ -176,9 +176,82 @@ async def test_suggestfeature_discord_exception(bot, monkeypatch):
     _patch_feature_service(
         monkeypatch,
         bot,
-        lambda title, summary: FeatureSuggestion(title=title, summary=summary),
+        lambda title, summary, image: FeatureSuggestion(title=title, summary=summary, image=image),
     )
 
     await dpytest.message('+suggestfeature "Dark Mode" Some summary.')
 
     assert dpytest.verify().message().contains().content("Failed to submit your feature suggestion")
+
+
+@pytest.mark.asyncio
+async def test_suggestfeature_image_url_sets_embed_image(bot, monkeypatch):
+    _block_dms(monkeypatch)
+    mock_channel = _make_forum_channel()
+    monkeypatch.setattr(bot, "get_channel", lambda _: mock_channel)
+    _patch_feature_service(
+        monkeypatch,
+        bot,
+        lambda title, summary, image=None: FeatureSuggestion(title=title, summary=summary, image=image),
+    )
+
+    await dpytest.message('+suggestfeature "Dark Mode" https://thread.com/image.png My summary')
+
+    embed = mock_channel.create_thread.call_args[1]["embed"]
+    assert embed.image.url == "https://thread.com/image.png"
+
+
+@pytest.mark.asyncio
+async def test_suggestfeature_no_image_leaves_embed_image_unset(bot, monkeypatch):
+    _block_dms(monkeypatch)
+    mock_channel = _make_forum_channel()
+    monkeypatch.setattr(bot, "get_channel", lambda _: mock_channel)
+    _patch_feature_service(
+        monkeypatch,
+        bot,
+        lambda title, summary, image=None: FeatureSuggestion(title=title, summary=summary, image=image),
+    )
+
+    await dpytest.message('+suggestfeature "Dark Mode" My summary')
+
+    embed = mock_channel.create_thread.call_args[1]["embed"]
+    assert embed.image.url is None
+
+
+@pytest.mark.asyncio
+async def test_suggestfeature_non_url_falls_through_to_summary(bot, monkeypatch):
+    _block_dms(monkeypatch)
+    mock_channel = _make_forum_channel()
+    monkeypatch.setattr(bot, "get_channel", lambda _: mock_channel)
+    _patch_feature_service(
+        monkeypatch,
+        bot,
+        lambda title, summary, image=None: FeatureSuggestion(title=title, summary=summary, image=image),
+    )
+
+    await dpytest.message('+suggestfeature "Dark Mode" Add dark theme')
+
+    embed = mock_channel.create_thread.call_args[1]["embed"]
+    field_map = {f.name: f.value for f in embed.fields}
+    assert field_map["Summary"] == "Add dark theme"
+    assert embed.image.url is None
+
+
+@pytest.mark.asyncio
+async def test_suggestfeature_attachment_used_when_no_url(bot, monkeypatch):
+    _block_dms(monkeypatch)
+    mock_channel = _make_forum_channel()
+    monkeypatch.setattr(bot, "get_channel", lambda _: mock_channel)
+    _patch_feature_service(
+        monkeypatch,
+        bot,
+        lambda title, summary, image=None: FeatureSuggestion(title=title, summary=summary, image=image),
+    )
+
+    await dpytest.message(
+        '+suggestfeature "Dark Mode" My summary',
+        attachments=["https://cdn.discordapp.com/x.png"],
+    )
+
+    embed = mock_channel.create_thread.call_args[1]["embed"]
+    assert embed.image.url == "https://cdn.discordapp.com/x.png"

--- a/tests/unit/test_feature_suggest_service.py
+++ b/tests/unit/test_feature_suggest_service.py
@@ -35,10 +35,17 @@ def test_create_feature_suggestion_raises_for_summary_too_long():
         create_feature_suggestion("Dark Mode", "B" * 1025)
 
 
-async def test_imageurl_converter_raises_for_non_https():
+async def test_imageurl_converter_raises_for_non_url():
     converter = ImageURL()
     with pytest.raises(commands.BadArgument):
         await converter.convert(None, "not-a-url")
+
+
+async def test_imageurl_converter_returns_url_for_http():
+    converter = ImageURL()
+    result = await converter.convert(None, "http://thread.com/image.png")
+
+    assert result == "http://thread.com/image.png"
 
 
 async def test_imageurl_converter_returns_url_for_https():
@@ -54,12 +61,18 @@ def test_create_feature_suggestion_defaults_image_to_none():
     assert result.image is None
 
 
-def test_create_feature_suggestion_stores_valid_image_url():
+def test_create_feature_suggestion_stores_https_image_url():
     result = create_feature_suggestion("Dark Mode", "Add a dark theme.", "https://thread.com/image.png")
 
     assert result.image == "https://thread.com/image.png"
 
 
-def test_create_feature_suggestion_raises_for_non_https_image():
+def test_create_feature_suggestion_stores_http_image_url():
+    result = create_feature_suggestion("Dark Mode", "Add a dark theme.", "http://thread.com/image.png")
+
+    assert result.image == "http://thread.com/image.png"
+
+
+def test_create_feature_suggestion_raises_for_invalid_scheme():
     with pytest.raises(ValueError, match="Image URL must be a direct"):
-        create_feature_suggestion("Dark Mode", "Short summary", "http://thread.com/image.png")
+        create_feature_suggestion("Dark Mode", "Short summary", "ftp://thread.com/image.png")

--- a/tests/unit/test_feature_suggest_service.py
+++ b/tests/unit/test_feature_suggest_service.py
@@ -30,9 +30,26 @@ def test_create_feature_suggestion_allows_max_summary_length():
     assert result.summary == "B" * 1024
 
 
-def test_create_feature_suggestion_raises_for_summary_too_long():
-    with pytest.raises(ValueError, match="The summary cannot exceed 1024 characters."):
-        create_feature_suggestion("Dark Mode", "B" * 1025)
+def test_chunk_short_summary_is_single():
+    result = create_feature_suggestion("Dark Mode", "Add a dark theme.")
+
+    assert result.summary_chunked == ["Add a dark theme."]
+
+
+def test_chunk_long_summary_splits_into_max_1024():
+    summary = " ".join(["word"] * 300)
+    result = create_feature_suggestion("Dark Mode", summary)
+
+    assert len(result.summary_chunked) > 1
+    assert all(len(c) <= 1024 for c in result.summary_chunked)
+    assert " ".join(result.summary_chunked) == summary
+
+
+def test_chunk_empty_summary_does_not_crash():
+    result = create_feature_suggestion("Dark Mode", "")
+
+    assert result.summary_chunked == [""]
+
 
 
 async def test_imageurl_converter_raises_for_non_url():

--- a/tests/unit/test_feature_suggest_service.py
+++ b/tests/unit/test_feature_suggest_service.py
@@ -1,6 +1,9 @@
 import pytest
 
+from discord.ext import commands
+
 from byte_bot.services.feature_suggest_service import create_feature_suggestion
+from byte_bot.cogs.feature_suggest import ImageURL
 
 
 def test_create_feature_suggestion_returns_dataclass_for_valid_input():
@@ -30,3 +33,33 @@ def test_create_feature_suggestion_allows_max_summary_length():
 def test_create_feature_suggestion_raises_for_summary_too_long():
     with pytest.raises(ValueError, match="The summary cannot exceed 1024 characters."):
         create_feature_suggestion("Dark Mode", "B" * 1025)
+
+
+async def test_imageurl_converter_raises_for_non_https():
+    converter = ImageURL()
+    with pytest.raises(commands.BadArgument):
+        await converter.convert(None, "not-a-url")
+
+
+async def test_imageurl_converter_returns_url_for_https():
+    converter = ImageURL()
+    result = await converter.convert(None, "https://thread.com/image.png")
+
+    assert result == "https://thread.com/image.png"
+
+
+def test_create_feature_suggestion_defaults_image_to_none():
+    result = create_feature_suggestion("Dark Mode", "Add a dark theme.")
+
+    assert result.image is None
+
+
+def test_create_feature_suggestion_stores_valid_image_url():
+    result = create_feature_suggestion("Dark Mode", "Add a dark theme.", "https://thread.com/image.png")
+
+    assert result.image == "https://thread.com/image.png"
+
+
+def test_create_feature_suggestion_raises_for_non_https_image():
+    with pytest.raises(ValueError, match="Image URL must be a direct"):
+        create_feature_suggestion("Dark Mode", "Short summary", "http://thread.com/image.png")


### PR DESCRIPTION
## Description:

Adds an optional `image` parameter to the `/+suggestfeature` hybrid command 
so users can attach a direct image URL that renders in the forum thread embed (`Embed.image`). 

- New `image` option on the hybrid command. Slash is URL-only (Discord can't attach files in slash commands); prefix commands also fall back to the first
  message attachment when no URL is given.
- URLs are validated as `https://` via an `ImageURL` converter and in the service layer.
- Used as `Optional[ImageURL]` so a non-URL word after the title is no longer stolen as the image, it falls through to    `summary`. A non-URL in the slash `image` field returns a friendly error.
- Adds unit tests (service validation + converter) and integration tests covering image-renders, no-image, 
  fall-through-to-summary, and the attachment fallback. Also updates the existing patched-service tests to the
  new `create_feature_suggestion(title, summary, image)` signature.
 
<img width="514" height="872" alt="image" src="https://github.com/user-attachments/assets/e7577840-1b30-4d05-9110-60c66592827d" />


## Linked Issue:

- [ISSUE-43](https://github.com/byte-club-hq/byte-bot/issues/43) - Add an optional image URL to the /suggestfeature command

## Testing Instructions:
1. **Slash, with image:** Run `/suggestfeature`, fill `title` and `summary`,
   then select the optional **`image`** option and paste a direct image URL
   (e.g. `https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png`).
   Confirm the new forum thread's embed shows the image.
2. **Prefix, with URL:** `+suggestfeature "Dark Mode" https://.../image.png My summary`
   -> image renders.
3. **Prefix, with file:** attach an image file to the message and send
   `+suggestfeature "Dark Mode" My summary` -> the attachment is used as the image.
4. **Prefix, no image:** `+suggestfeature "Dark Mode" My summary` -> no error,
   summary is together (no stolen word).
5. **Invalid URL (slash):** put a non-`http:// or https://` value in the `image` field ->
   friendly error, no thread created.
6. **Run the tests:**
   `.venv/bin/python -m pytest tests/unit/test_feature_suggest_service.py tests/integration/test_suggest_feature.py -v`

## Checklist:

- [X] PR has a meaningful title and description. **NOT**: `Merge branch into main`
- [X] I have linked the relevant issue(s) that this PR addresses.
- [X] I have fully tested all features present in this PR
- [ ] I have updated any relevant documentation (if applicable).
- [X] This PR fully addresses the linked issue(s). If not, I have explained why in the PR description.
